### PR TITLE
ThreatParallax Phase V analyst UX polish and navigation cleanup

### DIFF
--- a/ISSUE_ORDER.md
+++ b/ISSUE_ORDER.md
@@ -71,8 +71,8 @@ ThreatParallax Phase I covers UI rebrand, visual-system cleanup, shell moderniza
    Note: Promoted the critical KPI into the lead metric treatment, strengthened its supporting summary stat, and improved at-a-glance emphasis without changing the underlying metrics model or widening into a dashboard redesign.
 2. P5-02 [#32](https://github.com/nvrenuf/aitid/issues/32) Threat feed scanability and filter placement refinement - completed
    Note: Moved filters directly into the `/threats` results workflow and tightened row anatomy around severity, models, vectors, score, and age/patch context for faster analyst scanning.
-3. P5-03 [#33](https://github.com/nvrenuf/aitid/issues/33) Loading skeletons and perceived-performance polish - pending
-   Note: Replace bare loading text with restrained skeleton states on the most visible product surfaces.
+3. P5-03 [#33](https://github.com/nvrenuf/aitid/issues/33) Loading skeletons and perceived-performance polish - completed
+   Note: Replaced bare dashboard loading text with restrained skeleton shells on the overview and model feeds, keeping the async behavior lightweight and the motion subdued.
 4. P5-04 [#34](https://github.com/nvrenuf/aitid/issues/34) Hide SIEM from primary UX and tighten navigation polish - pending
    Note: Remove SIEM from the primary user-facing navigation and surfaces while keeping restoration practical later.
 5. P5-05 [#35](https://github.com/nvrenuf/aitid/issues/35) Final regression sweep, docs touch-up, and PR polish - pending

--- a/ISSUE_ORDER.md
+++ b/ISSUE_ORDER.md
@@ -69,8 +69,8 @@ ThreatParallax Phase I covers UI rebrand, visual-system cleanup, shell moderniza
 
 1. P5-01 [#31](https://github.com/nvrenuf/aitid/issues/31) Overview metric hierarchy and dashboard emphasis polish - completed
    Note: Promoted the critical KPI into the lead metric treatment, strengthened its supporting summary stat, and improved at-a-glance emphasis without changing the underlying metrics model or widening into a dashboard redesign.
-2. P5-02 [#32](https://github.com/nvrenuf/aitid/issues/32) Threat feed scanability and filter placement refinement - pending
-   Note: Tighten threat row anatomy and move filter interaction closer to the operator feed workflow without regressing current search/filter behavior.
+2. P5-02 [#32](https://github.com/nvrenuf/aitid/issues/32) Threat feed scanability and filter placement refinement - completed
+   Note: Moved filters directly into the `/threats` results workflow and tightened row anatomy around severity, models, vectors, score, and age/patch context for faster analyst scanning.
 3. P5-03 [#33](https://github.com/nvrenuf/aitid/issues/33) Loading skeletons and perceived-performance polish - pending
    Note: Replace bare loading text with restrained skeleton states on the most visible product surfaces.
 4. P5-04 [#34](https://github.com/nvrenuf/aitid/issues/34) Hide SIEM from primary UX and tighten navigation polish - pending

--- a/ISSUE_ORDER.md
+++ b/ISSUE_ORDER.md
@@ -64,3 +64,16 @@ ThreatParallax Phase I covers UI rebrand, visual-system cleanup, shell moderniza
    Note: Rebalanced the filter bar and workspace proportions, added a reset path and stage caption, and reshaped the regional detail panel into a stickier, faster-scanning operator brief without changing the underlying map meaning.
 5. P4-05 [#29](https://github.com/nvrenuf/aitid/issues/29) Final regression sweep, documentation touch-up, and PR polish - completed
    Note: Re-ran the final build and test pass, refreshed README for the projected Threat Map and Eastern Time behavior, verified the preserved route surfaces, and prepared the branch as the single draft PR review surface for Phase IV.
+
+## Phase V Execution Order
+
+1. P5-01 [#31](https://github.com/nvrenuf/aitid/issues/31) Overview metric hierarchy and dashboard emphasis polish - completed
+   Note: Promoted the critical KPI into the lead metric treatment, strengthened its supporting summary stat, and improved at-a-glance emphasis without changing the underlying metrics model or widening into a dashboard redesign.
+2. P5-02 [#32](https://github.com/nvrenuf/aitid/issues/32) Threat feed scanability and filter placement refinement - pending
+   Note: Tighten threat row anatomy and move filter interaction closer to the operator feed workflow without regressing current search/filter behavior.
+3. P5-03 [#33](https://github.com/nvrenuf/aitid/issues/33) Loading skeletons and perceived-performance polish - pending
+   Note: Replace bare loading text with restrained skeleton states on the most visible product surfaces.
+4. P5-04 [#34](https://github.com/nvrenuf/aitid/issues/34) Hide SIEM from primary UX and tighten navigation polish - pending
+   Note: Remove SIEM from the primary user-facing navigation and surfaces while keeping restoration practical later.
+5. P5-05 [#35](https://github.com/nvrenuf/aitid/issues/35) Final regression sweep, docs touch-up, and PR polish - pending
+   Note: Re-run the final build/test pass, refresh docs where needed, and prepare the branch as the single draft PR review surface for Phase V.

--- a/ISSUE_ORDER.md
+++ b/ISSUE_ORDER.md
@@ -75,5 +75,5 @@ ThreatParallax Phase I covers UI rebrand, visual-system cleanup, shell moderniza
    Note: Replaced bare dashboard loading text with restrained skeleton shells on the overview and model feeds, keeping the async behavior lightweight and the motion subdued.
 4. P5-04 [#34](https://github.com/nvrenuf/aitid/issues/34) Hide SIEM from primary UX and tighten navigation polish - completed
    Note: Hid the SIEM workspace tab and panel behind a recoverable feature flag, then tightened the surrounding workspace copy so the primary UX stays focused on the active analyst surfaces.
-5. P5-05 [#35](https://github.com/nvrenuf/aitid/issues/35) Final regression sweep, docs touch-up, and PR polish - pending
-   Note: Re-run the final build/test pass, refresh docs where needed, and prepare the branch as the single draft PR review surface for Phase V.
+5. P5-05 [#35](https://github.com/nvrenuf/aitid/issues/35) Final regression sweep, docs touch-up, and PR polish - completed
+   Note: Re-ran the final build/test pass, refreshed README for the Phase V analyst UX state, and prepared the branch as the single draft PR review surface for Phase V.

--- a/ISSUE_ORDER.md
+++ b/ISSUE_ORDER.md
@@ -73,7 +73,7 @@ ThreatParallax Phase I covers UI rebrand, visual-system cleanup, shell moderniza
    Note: Moved filters directly into the `/threats` results workflow and tightened row anatomy around severity, models, vectors, score, and age/patch context for faster analyst scanning.
 3. P5-03 [#33](https://github.com/nvrenuf/aitid/issues/33) Loading skeletons and perceived-performance polish - completed
    Note: Replaced bare dashboard loading text with restrained skeleton shells on the overview and model feeds, keeping the async behavior lightweight and the motion subdued.
-4. P5-04 [#34](https://github.com/nvrenuf/aitid/issues/34) Hide SIEM from primary UX and tighten navigation polish - pending
-   Note: Remove SIEM from the primary user-facing navigation and surfaces while keeping restoration practical later.
+4. P5-04 [#34](https://github.com/nvrenuf/aitid/issues/34) Hide SIEM from primary UX and tighten navigation polish - completed
+   Note: Hid the SIEM workspace tab and panel behind a recoverable feature flag, then tightened the surrounding workspace copy so the primary UX stays focused on the active analyst surfaces.
 5. P5-05 [#35](https://github.com/nvrenuf/aitid/issues/35) Final regression sweep, docs touch-up, and PR polish - pending
    Note: Re-run the final build/test pass, refresh docs where needed, and prepare the branch as the single draft PR review surface for Phase V.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ThreatParallax is an AI Threat Intelligence Platform for security leaders and analysts tracking model-linked threats, distribution vectors, operational exposure, and conservative regional map context across the current non-production deployment.
 
-Phase IV keeps the existing Vercel deployment model and current repo name in place while upgrading Threat Map into a projected world-map surface, repairing map interaction resilience, and normalizing visible product timestamps to America/New_York with DST-aware EST/EDT output. Domain cutover remains out of scope.
+Phase V keeps the existing Vercel deployment model and current repo name in place while polishing analyst usability: stronger overview metric hierarchy, faster threat-feed scanning, calmer loading states, and a tighter primary UX with SIEM removed from the current main workflow. Threat Map and timestamp normalization from Phase IV remain intact. Domain cutover remains out of scope.
 
 ## Product surfaces
 
 - `/overview`: primary leadership and analyst workspace, including the existing dashboard/feed internals
-- `/threats`: operator-oriented corpus scanning with search, filters, and sort controls
+- `/threats`: operator-oriented corpus scanning with search, filters, sort controls, and faster row-level scanning context
 - `/threats/[slug]`: canonical threat detail pages for direct review and deep linking
 - `/threat-map`: conservative projected world map surface for observed infrastructure and exposure geography with regional drilldowns
 - `/research`: light methodology, source, and cadence framing
@@ -16,6 +16,7 @@ Phase IV keeps the existing Vercel deployment model and current repo name in pla
 
 - Visible product timestamps render in `America/New_York` and use the correct short timezone abbreviation automatically (`EST` or `EDT`).
 - Threat Map remains limited to observed infrastructure and exposure geography. It does not claim actor origin, victim geography, or live attack traffic.
+- SIEM integration remains available in code and environment configuration, but it is intentionally hidden from the current primary user-facing workflow.
 
 ## Stack
 

--- a/src/components/dashboard/DashboardShell.astro
+++ b/src/components/dashboard/DashboardShell.astro
@@ -1,5 +1,6 @@
 ---
 import { PRODUCT_ROUTES } from '../../lib/product-navigation.js';
+import { SHOW_SIEM_IN_PRIMARY_UX } from '../../lib/feature-flags.js';
 
 const { now, currentPath, routeMeta, showWorkspaceNav = false } = Astro.props;
 
@@ -10,14 +11,17 @@ const shellTabs = [
   { id: 'copilot', label: 'Copilot', badgeId: 'badge-copilot', badge: '--' },
   { id: 'oss', label: 'OSS / HuggingFace', badgeId: 'badge-oss', badge: '--' },
   { id: 'vectors', label: 'Vectors', badgeId: 'badge-vectors', badge: '--' },
-  {
+];
+
+if (SHOW_SIEM_IN_PRIMARY_UX) {
+  shellTabs.push({
     id: 'siem',
     label: 'SIEM Config',
     badgeId: 'badge-siem',
     badge: 'stub',
     badgeStyle: 'background:var(--info-bg);color:var(--info)',
-  },
-];
+  });
+}
 ---
 
 <header class="hdr">
@@ -87,7 +91,7 @@ const shellTabs = [
       <div class="shell-nav-meta">
         <div class="shell-label">Overview workspace</div>
         <div class="shell-note">
-          Existing feed, model, vector, and SIEM panels stay live inside the Overview surface.
+          Existing feed, model, and vector panels stay live inside the Overview surface without widening the current primary workflow.
         </div>
       </div>
       <nav class="tabbar" id="tabbar" aria-label="Overview workspace views">
@@ -104,7 +108,7 @@ const shellTabs = [
       </nav>
       <div class="shell-future">
         <span class="future-chip">Dashboard internals preserved</span>
-        <span class="future-chip">Route shell ready for deeper pages</span>
+        <span class="future-chip">Primary workflow kept focused</span>
       </div>
     </div>
   )

--- a/src/components/dashboard/MetricsStrip.astro
+++ b/src/components/dashboard/MetricsStrip.astro
@@ -3,15 +3,6 @@ const { initialStats } = Astro.props;
 
 const metrics = [
   {
-    label: 'Active campaigns',
-    description: 'Current threat records requiring ongoing monitoring in the platform queue.',
-    accent: 'ACT',
-    value: initialStats.totalThreats,
-    valueId: 'm-total',
-    context: 'Across the current tracked set',
-    deltaId: 'm-total-d',
-  },
-  {
     label: 'Critical severity',
     description: 'Highest-priority issues still active and likely to drive escalation decisions.',
     accent: 'CRI',
@@ -22,6 +13,16 @@ const metrics = [
     context: 'Immediate attention window',
     deltaId: 'm-crit-d',
     deltaClass: 'up',
+    cardClass: 'primary',
+  },
+  {
+    label: 'Active campaigns',
+    description: 'Current threat records requiring ongoing monitoring in the platform queue.',
+    accent: 'ACT',
+    value: initialStats.totalThreats,
+    valueId: 'm-total',
+    context: 'Across the current tracked set',
+    deltaId: 'm-total-d',
   },
   {
     label: 'New this week',
@@ -51,7 +52,7 @@ const metrics = [
 <div class="metrics" id="metrics-strip">
   {
     metrics.map((metric) => (
-      <div class="metric">
+      <div class:list={['metric', metric.cardClass]}>
         <div class="metric-top">
           <div>
             <div class="m-label">{metric.label}</div>

--- a/src/components/dashboard/ModelFeedPanel.astro
+++ b/src/components/dashboard/ModelFeedPanel.astro
@@ -13,6 +13,27 @@ const { panel } = Astro.props;
     }
   </div>
   <div class="panel-scroll">
-    <div id={`feed-${panel.id}`}><div class="loading"><span class="spinner"></span>Loading...</div></div>
+    <div id={`feed-${panel.id}`}>
+      <div class="loading-shell loading-shell-compact" aria-live="polite" aria-label={`Loading ${panel.label} threats`}>
+        <div class="loading-card">
+          <div class="loading-card-head">
+            <div class="loading-pill-row">
+              <span class="loading-pill"></span>
+              <span class="loading-pill"></span>
+            </div>
+            <span class="loading-mini-card"></span>
+          </div>
+          <div class="loading-stack">
+            <span class="loading-line loading-line-lg"></span>
+            <span class="loading-line loading-line-md"></span>
+          </div>
+          <div class="loading-grid">
+            <span class="loading-panel"></span>
+            <span class="loading-panel"></span>
+          </div>
+        </div>
+        <div class="loading-copy">Preparing model-specific feed.</div>
+      </div>
+    </div>
   </div>
 </div>

--- a/src/components/dashboard/OverviewPanel.astro
+++ b/src/components/dashboard/OverviewPanel.astro
@@ -73,7 +73,46 @@ const overviewStats = [
         }
       </div>
       <div class="shdr"><span>Live threat feed</span><span>blended CVSS + ATLAS score</span></div>
-      <div id="overview-feed"><div class="loading"><span class="spinner"></span>Loading threats...</div></div>
+      <div id="overview-feed">
+        <div class="loading-shell" aria-live="polite" aria-label="Loading threat feed">
+          <div class="loading-card">
+            <div class="loading-card-head">
+              <div class="loading-pill-row">
+                <span class="loading-pill"></span>
+                <span class="loading-pill"></span>
+                <span class="loading-pill loading-pill-wide"></span>
+              </div>
+              <span class="loading-mini-card"></span>
+            </div>
+            <div class="loading-stack">
+              <span class="loading-line loading-line-lg"></span>
+              <span class="loading-line loading-line-md"></span>
+            </div>
+            <div class="loading-grid">
+              <span class="loading-panel"></span>
+              <span class="loading-panel"></span>
+            </div>
+          </div>
+          <div class="loading-card">
+            <div class="loading-card-head">
+              <div class="loading-pill-row">
+                <span class="loading-pill"></span>
+                <span class="loading-pill"></span>
+              </div>
+              <span class="loading-mini-card"></span>
+            </div>
+            <div class="loading-stack">
+              <span class="loading-line loading-line-lg"></span>
+              <span class="loading-line loading-line-sm"></span>
+            </div>
+            <div class="loading-grid">
+              <span class="loading-panel"></span>
+              <span class="loading-panel"></span>
+            </div>
+          </div>
+          <div class="loading-copy">Preparing current threats and score context.</div>
+        </div>
+      </div>
     </div>
     <div class="resize-handle" id="sidebar-resize-handle"></div>
     <div class="sidebar" id="overview-sidebar" style="width:260px;min-width:160px;max-width:520px;overflow-y:auto;flex-shrink:0">

--- a/src/components/dashboard/OverviewPanel.astro
+++ b/src/components/dashboard/OverviewPanel.astro
@@ -18,7 +18,7 @@ const overviewFilters = [
 ];
 
 const overviewStats = [
-  { label: 'Critical active', id: 'overview-critical', value: initialStats.activeCritical },
+  { label: 'Critical active', id: 'overview-critical', value: initialStats.activeCritical, className: 'critical' },
   { label: 'Models in scope', id: 'overview-models', value: initialStats.modelsAffected },
   { label: 'New this week', id: 'overview-week', value: initialStats.newThisWeek },
   { label: 'Tracked items', id: 'overview-total', value: initialStats.totalThreats },
@@ -53,7 +53,7 @@ const overviewStats = [
           <div class="overview-grid">
             {
               overviewStats.map((stat) => (
-                <div class="overview-stat">
+                <div class:list={['overview-stat', stat.className]}>
                   <div class="m-label">{stat.label}</div>
                   <span id={stat.id}>{stat.value}</span>
                 </div>

--- a/src/components/dashboard/SecondaryPanels.astro
+++ b/src/components/dashboard/SecondaryPanels.astro
@@ -1,5 +1,6 @@
 ---
 import ModelFeedPanel from './ModelFeedPanel.astro';
+import { SHOW_SIEM_IN_PRIMARY_UX } from '../../lib/feature-flags.js';
 
 const modelPanels = [
   {
@@ -62,46 +63,50 @@ const modelPanels = [
   </div>
 </div>
 
-<div class="panel" id="panel-siem">
-  <div class="panel-scroll">
-    <div class="siem-stub">
-      <div class="siem-stub-title">SIEM / SOAR Integration</div>
-      <div class="siem-stub-body">
-        Connect your SIEM to receive structured threat events. Each event includes severity, blended
-        CVSS+ATLAS score, affected models, vectors, IOCs, and STIX 2.1 object.
-        <br /><br />
-        Supported targets: Microsoft Sentinel, Splunk HEC, Elastic, CrowdStrike Falcon, generic
-        webhook.
-      </div>
-      <div class="siem-config-rows">
-        <div class="siem-row">
-          <label>SIEM type</label>
-          <select id="sc-type">
-            <option value="">— select —</option>
-            <option>sentinel</option>
-            <option>splunk</option>
-            <option>elastic</option>
-            <option>crowdstrike</option>
-            <option>webhook</option>
-          </select>
+{
+  SHOW_SIEM_IN_PRIMARY_UX && (
+    <div class="panel" id="panel-siem">
+      <div class="panel-scroll">
+        <div class="siem-stub">
+          <div class="siem-stub-title">SIEM / SOAR Integration</div>
+          <div class="siem-stub-body">
+            Connect your SIEM to receive structured threat events. Each event includes severity, blended
+            CVSS+ATLAS score, affected models, vectors, IOCs, and STIX 2.1 object.
+            <br /><br />
+            Supported targets: Microsoft Sentinel, Splunk HEC, Elastic, CrowdStrike Falcon, generic
+            webhook.
+          </div>
+          <div class="siem-config-rows">
+            <div class="siem-row">
+              <label>SIEM type</label>
+              <select id="sc-type">
+                <option value="">— select —</option>
+                <option>sentinel</option>
+                <option>splunk</option>
+                <option>elastic</option>
+                <option>crowdstrike</option>
+                <option>webhook</option>
+              </select>
+            </div>
+            <div class="siem-row"><label>Webhook / HEC URL</label><input type="url" id="sc-url" placeholder="https://..." /></div>
+            <div class="siem-row"><label>Secret / token</label><input type="password" id="sc-secret" placeholder="•••••••••" /></div>
+            <div class="siem-row">
+              <label>Min severity</label>
+              <select id="sc-minsev">
+                <option value="critical">Critical only</option>
+                <option value="high" selected>High+</option>
+                <option value="medium">Medium+</option>
+              </select>
+            </div>
+          </div>
+          <div class="siem-export-btns">
+            <button class="export-btn" onclick="exportStix()">Export STIX 2.1 bundle</button>
+            <button class="export-btn" onclick="exportCsv()">Export CSV</button>
+            <button class="export-btn" onclick="exportJson()">Export JSON</button>
+            <button class="export-btn" style="color:var(--info)" onclick="saveSiemConfig()">Save config →</button>
+          </div>
         </div>
-        <div class="siem-row"><label>Webhook / HEC URL</label><input type="url" id="sc-url" placeholder="https://..." /></div>
-        <div class="siem-row"><label>Secret / token</label><input type="password" id="sc-secret" placeholder="•••••••••" /></div>
-        <div class="siem-row">
-          <label>Min severity</label>
-          <select id="sc-minsev">
-            <option value="critical">Critical only</option>
-            <option value="high" selected>High+</option>
-            <option value="medium">Medium+</option>
-          </select>
-        </div>
-      </div>
-      <div class="siem-export-btns">
-        <button class="export-btn" onclick="exportStix()">Export STIX 2.1 bundle</button>
-        <button class="export-btn" onclick="exportCsv()">Export CSV</button>
-        <button class="export-btn" onclick="exportJson()">Export JSON</button>
-        <button class="export-btn" style="color:var(--info)" onclick="saveSiemConfig()">Save config →</button>
       </div>
     </div>
-  </div>
-</div>
+  )
+}

--- a/src/components/layout/ProductLayout.astro
+++ b/src/components/layout/ProductLayout.astro
@@ -65,12 +65,15 @@ const routeMeta = getRouteMeta(currentPath);
     .tbadge { font-size: 10px; font-family: var(--font-sans); padding: 1px 5px; border-radius: 3px; background: var(--bg2); color: var(--txt3); transition: background .1s; }
     .tab.active .tbadge { background: var(--txt); color: var(--bg); }
     .tbadge.warn { background: var(--crit-bg); color: var(--crit); }
-    .metrics { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 12px; flex-shrink: 0; }
-    .metric { padding: 18px 20px 20px; display: grid; gap: 14px; position: relative; overflow: hidden; }
+    .metrics { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 12px; flex-shrink: 0; }
+    .metric { grid-column: span 3; padding: 18px 20px 20px; display: grid; gap: 14px; position: relative; overflow: hidden; }
     .metric::before { content: ''; position: absolute; inset: 0 0 auto; height: 1px; background: linear-gradient(90deg, transparent, rgba(255,255,255,.22), transparent); opacity: .8; }
+    .metric.primary { grid-column: span 6; padding: 22px 24px 24px; background: linear-gradient(180deg, rgba(255,107,107,.12), rgba(255,107,107,.04) 52%, rgba(255,255,255,.02)); border-color: rgba(255,107,107,.18); box-shadow: 0 18px 40px rgba(0,0,0,.18), inset 0 1px 0 rgba(255,255,255,.06); }
+    .metric.primary::after { content: 'Priority'; position: absolute; top: 16px; right: 18px; padding: 5px 9px; border-radius: 999px; border: 1px solid rgba(255,107,107,.24); background: rgba(255,107,107,.08); color: var(--crit); font-size: 10px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
     .metric-top { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
     .metric-top .m-label { margin-bottom: 6px; }
     .metric-top p { color: var(--txt2); font-size: 12px; line-height: 1.5; max-width: 24ch; }
+    .metric.primary .metric-top p { max-width: 36ch; font-size: 13px; }
     .metric-accent { width: 38px; height: 38px; border-radius: 12px; border: 1px solid var(--border2); background: rgba(255,255,255,.04); display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 800; color: var(--txt2); box-shadow: inset 0 1px 0 rgba(255,255,255,.06); }
     .metric-accent.crit { color: var(--crit); background: rgba(255,107,107,.08); border-color: var(--crit-border); }
     .metric-accent.amber { color: var(--med); background: rgba(255,211,105,.08); border-color: var(--med-border); }
@@ -78,6 +81,7 @@ const routeMeta = getRouteMeta(currentPath);
     .metric-bottom { display: flex; align-items: flex-end; justify-content: space-between; gap: 12px; }
     .m-label { margin-bottom: 8px; }
     .m-val { font-size: clamp(32px, 4vw, 40px); font-weight: 600; font-family: var(--font-display); line-height: .95; margin-bottom: 6px; letter-spacing: -0.05em; }
+    .metric.primary .m-val { font-size: clamp(42px, 5vw, 56px); margin-bottom: 8px; }
     .m-val.crit { color: var(--crit); }
     .m-val.amber { color: var(--med); }
     .m-context { font-size: 11px; color: var(--txt3); font-weight: 700; }
@@ -115,6 +119,8 @@ const routeMeta = getRouteMeta(currentPath);
     .overview-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
     .overview-stat { padding: 12px 14px; border-radius: 12px; border: 1px solid var(--border); background: rgba(7,16,24,.44); }
     .overview-stat span { display: block; margin-top: 6px; color: var(--txt); font-size: 17px; font-weight: 700; letter-spacing: -0.03em; }
+    .overview-stat.critical { background: linear-gradient(180deg, rgba(255,107,107,.12), rgba(255,107,107,.04)); border-color: rgba(255,107,107,.22); box-shadow: inset 0 1px 0 rgba(255,255,255,.05); }
+    .overview-stat.critical span { color: var(--crit); font-size: 26px; }
     .body { display: grid; grid-template-columns: 1fr 260px; flex: 1; min-height: 0; }
     .feed-col { overflow-y: auto; }
     .sidebar { overflow-y: auto; }
@@ -245,6 +251,8 @@ const routeMeta = getRouteMeta(currentPath);
       .overview-frame { grid-template-columns: 1fr; }
       .overview-grid { grid-template-columns: 1fr; }
       .metrics { grid-template-columns: repeat(2, 1fr); }
+      .metric,
+      .metric.primary { grid-column: span 1; }
       .tc-band { grid-template-columns: 1fr; }
       .drawer-hero { grid-template-columns: 1fr; }
       .drawer-grid { grid-template-columns: 1fr; }

--- a/src/components/layout/ProductLayout.astro
+++ b/src/components/layout/ProductLayout.astro
@@ -134,6 +134,33 @@ const routeMeta = getRouteMeta(currentPath);
     .fpill.active { background: var(--txt); color: var(--bg); border-color: var(--txt); }
     .shdr { padding: 10px 20px; border-bottom: 0.5px solid var(--border); display: flex; align-items: center; justify-content: space-between; position: sticky; top: 44px; background: rgba(9,19,29,.88); z-index: 9; }
     .feed-stack { display: grid; gap: 0; padding: 2px 0 14px; }
+    .loading-shell { display: grid; gap: 14px; padding: 16px 14px 18px; }
+    .loading-shell-compact { padding-top: 14px; }
+    .loading-card { padding: 18px; border: 1px solid var(--border); border-radius: var(--radius-md); background: linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.015)); display: grid; gap: 14px; box-shadow: var(--shadow-soft); }
+    .loading-card-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+    .loading-pill-row { display: flex; gap: 6px; flex-wrap: wrap; }
+    .loading-pill,
+    .loading-mini-card,
+    .loading-line,
+    .loading-panel { display: block; position: relative; overflow: hidden; background: rgba(255,255,255,.06); border: 1px solid rgba(139, 162, 191, 0.1); }
+    .loading-pill::after,
+    .loading-mini-card::after,
+    .loading-line::after,
+    .loading-panel::after { content: ''; position: absolute; inset: 0; transform: translateX(-100%); background: linear-gradient(90deg, transparent, rgba(255,255,255,.08), transparent); animation: skeleton-shift 2.1s ease-in-out infinite; }
+    .loading-pill { width: 64px; height: 24px; border-radius: 999px; }
+    .loading-pill-wide { width: 96px; }
+    .loading-mini-card { width: 88px; height: 54px; border-radius: 12px; }
+    .loading-stack { display: grid; gap: 10px; }
+    .loading-line { height: 12px; border-radius: 999px; }
+    .loading-line-lg { width: min(72%, 420px); }
+    .loading-line-md { width: min(56%, 320px); }
+    .loading-line-sm { width: min(44%, 260px); }
+    .loading-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+    .loading-panel { min-height: 78px; border-radius: 12px; }
+    .loading-copy { color: var(--txt3); font-size: 12px; line-height: 1.5; padding: 0 4px; }
+    @keyframes skeleton-shift {
+      100% { transform: translateX(100%); }
+    }
     .tcard { margin: 14px 14px 0; padding: 18px; border: 1px solid var(--border); border-radius: var(--radius-md); background: linear-gradient(180deg, rgba(255,255,255,.03), rgba(255,255,255,.015)); cursor: pointer; transition: transform .12s ease, border-color .12s ease, background .12s ease, box-shadow .12s ease; box-shadow: var(--shadow-soft); display: grid; gap: 14px; }
     .tcard:hover, .tcard.active { background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.02)); border-color: rgba(139, 162, 191, 0.34); transform: translateY(-1px); }
     .tc-kicker { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
@@ -257,6 +284,13 @@ const routeMeta = getRouteMeta(currentPath);
       .drawer-hero { grid-template-columns: 1fr; }
       .drawer-grid { grid-template-columns: 1fr; }
       .info-card-grid { grid-template-columns: 1fr; }
+      .loading-grid { grid-template-columns: 1fr; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .loading-pill::after,
+      .loading-mini-card::after,
+      .loading-line::after,
+      .loading-panel::after { animation: none; }
     }
   </style>
 </head>

--- a/src/components/threats/ThreatsSurface.astro
+++ b/src/components/threats/ThreatsSurface.astro
@@ -43,73 +43,6 @@ const initialThreats = JSON.stringify(threats);
   </div>
 
   <div class="threats-workspace">
-    <aside class="threats-controls">
-      <div class="page-kicker">Operator workflow</div>
-      <div class="threats-filter-stack">
-        <label class="threats-field">
-          <span>Search corpus</span>
-          <input
-            id="threats-search"
-            class="threats-input"
-            type="search"
-            placeholder="Search title, source, TTP, IOC, model, vector"
-          />
-        </label>
-
-        <label class="threats-field">
-          <span>Severity</span>
-          <select id="threats-severity" class="threats-select">
-            <option value="">All severities</option>
-            {filters.severities.map((severity) => <option value={severity}>{severity}</option>)}
-          </select>
-        </label>
-
-        <label class="threats-field">
-          <span>Model</span>
-          <select id="threats-model" class="threats-select">
-            <option value="">All models</option>
-            {
-              filters.models.map((model) => (
-                <option value={model}>{shortModel(model)}</option>
-              ))
-            }
-          </select>
-        </label>
-
-        <label class="threats-field">
-          <span>Vector</span>
-          <select id="threats-vector" class="threats-select">
-            <option value="">All vectors</option>
-            {filters.vectors.map((vector) => <option value={vector}>{vector}</option>)}
-          </select>
-        </label>
-
-        <label class="threats-field">
-          <span>Status</span>
-          <select id="threats-status" class="threats-select">
-            <option value="">All statuses</option>
-            {filters.statuses.map((status) => <option value={status}>{status}</option>)}
-          </select>
-        </label>
-
-        <label class="threats-field">
-          <span>Sort</span>
-          <select id="threats-sort" class="threats-select">
-            {THREAT_SORT_OPTIONS.map((option) => <option value={option.value}>{option.label}</option>)}
-          </select>
-        </label>
-      </div>
-
-      <div class="info-card threats-note">
-        <span>What this route does</span>
-        <p>
-          Filters are intentionally practical: severity, model, vector, status, and text search on the
-          current data model. Saved views, bulk actions, and account-specific state stay out of scope for
-          Phase III.
-        </p>
-      </div>
-    </aside>
-
     <div class="threats-results-shell">
       <div class="threats-results-head">
         <div>
@@ -120,6 +53,80 @@ const initialThreats = JSON.stringify(threats);
           <span class="future-chip">All threats</span>
         </div>
       </div>
+
+      <section class="threats-controls">
+        <div class="threats-controls-head">
+          <div>
+            <div class="page-kicker">Operator workflow</div>
+            <p class="threats-controls-copy">
+              Filters sit directly above the corpus so search, scoping, and prioritization happen in the
+              same visual lane as the feed.
+            </p>
+          </div>
+          <div class="info-card threats-note">
+            <span>Workflow guardrails</span>
+            <p>
+              Filters stay intentionally practical: severity, model, vector, status, and text search on
+              the current data model only.
+            </p>
+          </div>
+        </div>
+
+        <div class="threats-filter-stack">
+          <label class="threats-field threats-field-search">
+            <span>Search corpus</span>
+            <input
+              id="threats-search"
+              class="threats-input"
+              type="search"
+              placeholder="Search title, source, TTP, IOC, model, vector"
+            />
+          </label>
+
+          <label class="threats-field">
+            <span>Severity</span>
+            <select id="threats-severity" class="threats-select">
+              <option value="">All severities</option>
+              {filters.severities.map((severity) => <option value={severity}>{severity}</option>)}
+            </select>
+          </label>
+
+          <label class="threats-field">
+            <span>Model</span>
+            <select id="threats-model" class="threats-select">
+              <option value="">All models</option>
+              {
+                filters.models.map((model) => (
+                  <option value={model}>{shortModel(model)}</option>
+                ))
+              }
+            </select>
+          </label>
+
+          <label class="threats-field">
+            <span>Vector</span>
+            <select id="threats-vector" class="threats-select">
+              <option value="">All vectors</option>
+              {filters.vectors.map((vector) => <option value={vector}>{vector}</option>)}
+            </select>
+          </label>
+
+          <label class="threats-field">
+            <span>Status</span>
+            <select id="threats-status" class="threats-select">
+              <option value="">All statuses</option>
+              {filters.statuses.map((status) => <option value={status}>{status}</option>)}
+            </select>
+          </label>
+
+          <label class="threats-field">
+            <span>Sort</span>
+            <select id="threats-sort" class="threats-select">
+              {THREAT_SORT_OPTIONS.map((option) => <option value={option.value}>{option.label}</option>)}
+            </select>
+          </label>
+        </div>
+      </section>
 
       <div class="threats-results-meta">
         <div class="info-card">
@@ -157,9 +164,7 @@ const initialThreats = JSON.stringify(threats);
 
   .threats-workspace {
     display: grid;
-    grid-template-columns: minmax(260px, 300px) minmax(0, 1fr);
     gap: 18px;
-    align-items: start;
   }
 
   .threats-controls,
@@ -173,13 +178,35 @@ const initialThreats = JSON.stringify(threats);
     padding: 18px;
     display: grid;
     gap: 18px;
-    position: sticky;
-    top: 16px;
+    background:
+      linear-gradient(180deg, rgba(125, 196, 255, 0.08), rgba(125, 196, 255, 0.02)),
+      rgba(255, 255, 255, 0.02);
+  }
+
+  .threats-controls-head {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: start;
+  }
+
+  .threats-controls-copy {
+    margin-top: 8px;
+    max-width: 58ch;
+    color: var(--txt2);
+    font-size: 13px;
+    line-height: 1.65;
   }
 
   .threats-filter-stack {
     display: grid;
     gap: 12px;
+    grid-template-columns: minmax(0, 1.8fr) repeat(5, minmax(0, 1fr));
+    align-items: end;
+  }
+
+  .threats-field-search {
+    grid-column: span 1;
   }
 
   .threats-field {
@@ -243,6 +270,14 @@ const initialThreats = JSON.stringify(threats);
     gap: 14px;
   }
 
+  .threat-row-eyebrow {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: start;
+    flex-wrap: wrap;
+  }
+
   .threat-row-head,
   .threat-row-meta,
   .threat-row-foot {
@@ -272,6 +307,42 @@ const initialThreats = JSON.stringify(threats);
     color: var(--txt2);
     font-size: 13px;
     line-height: 1.65;
+  }
+
+  .threat-row-scan {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .threat-row-scan-item {
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: rgba(255,255,255,.025);
+    padding: 12px 13px;
+    display: grid;
+    gap: 6px;
+    min-height: 84px;
+  }
+
+  .threat-row-scan-item span {
+    font-size: 10px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--txt3);
+    font-weight: 700;
+  }
+
+  .threat-row-scan-item strong {
+    font-size: 15px;
+    line-height: 1.25;
+    color: var(--txt);
+  }
+
+  .threat-row-scan-item p {
+    color: var(--txt2);
+    font-size: 12px;
+    line-height: 1.5;
   }
 
   .threat-row-groups {
@@ -306,6 +377,18 @@ const initialThreats = JSON.stringify(threats);
     font-weight: 700;
   }
 
+  .threat-row-date {
+    color: var(--txt3);
+    font-size: 12px;
+    line-height: 1.5;
+    text-align: right;
+  }
+
+  .threats-note {
+    min-width: min(320px, 100%);
+    max-width: 360px;
+  }
+
   .threat-empty {
     padding: 28px;
     border: 1px dashed var(--border);
@@ -321,13 +404,33 @@ const initialThreats = JSON.stringify(threats);
       grid-template-columns: 1fr;
     }
 
-    .threats-controls {
-      position: static;
+    .threats-controls-head,
+    .threat-row-scan {
+      grid-template-columns: 1fr;
+      display: grid;
+    }
+
+    .threats-filter-stack {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .threats-field-search {
+      grid-column: 1 / -1;
     }
 
     .threats-kpis,
     .threat-row-groups {
       grid-template-columns: 1fr;
+    }
+  }
+
+  @media (max-width: 720px) {
+    .threats-filter-stack {
+      grid-template-columns: 1fr;
+    }
+
+    .threat-row-date {
+      text-align: left;
     }
   }
 </style>

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,3 @@
+// Keep recoverable feature switches in one place so product-facing surfaces can
+// hide unfinished work without deleting the underlying implementation.
+export const SHOW_SIEM_IN_PRIMARY_UX = false;

--- a/src/scripts/threats-client.js
+++ b/src/scripts/threats-client.js
@@ -61,19 +61,56 @@ function formatDate(value) {
   return formatEasternDate(value);
 }
 
+function formatThreatAge(value) {
+  const publishedAt = new Date(value);
+  if (Number.isNaN(publishedAt.getTime())) return 'Unknown age';
+
+  const diffMs = Date.now() - publishedAt.getTime();
+  const diffDays = Math.max(0, Math.floor(diffMs / 86400000));
+
+  if (diffDays === 0) return 'Published today';
+  if (diffDays === 1) return '1 day old';
+  if (diffDays < 14) return `${diffDays} days old`;
+
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks === 1) return '1 week old';
+  if (diffWeeks < 8) return `${diffWeeks} weeks old`;
+
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths <= 1) return '1 month old';
+  return `${diffMonths} months old`;
+}
+
 function resultCard(threat) {
   const models = threat.models.map((model) => badge(shortModel(model), 'b-model')).join('');
   const vectors = threat.vectors.map((vector) => badge(vector, 'b-gray')).join('');
   const ttpIds = threat.ttps.map((ttp) => `<span class="ttp-tag">${escapeHtml(ttp.id)}</span>`).join('');
   const patchLine = threat.patchVersion ? `Patch ${escapeHtml(threat.patchVersion)}` : 'Patch not listed';
   const detailHref = getThreatDetailHref(threat);
+  const topModels = threat.models.slice(0, 2).map((model) => shortModel(model)).join(', ');
+  const topVectors = threat.vectors.slice(0, 2).join(', ');
+  const ageLabel = formatThreatAge(threat.publishedAt);
 
   return `
     <article class="threat-row">
+      <div class="threat-row-eyebrow">
+        <div class="tc-meta">
+          ${badge(threat.severity.toUpperCase(), severityClasses[threat.severity] ?? 'b-gray')}
+          ${badge(threat.status, statusClasses[threat.status] ?? 'b-gray')}
+          ${badge(threat.type, 'b-gray')}
+          ${threat.cve ? `<span class="ttp-tag">${escapeHtml(threat.cve)}</span>` : ''}
+        </div>
+        <div class="threat-row-date">
+          <div>Published ${formatDate(threat.publishedAt)}</div>
+          <div>Updated ${formatDate(threat.updatedAt)}</div>
+        </div>
+      </div>
+
       <div class="threat-row-head">
         <div>
           <div class="threat-row-title"><a class="threat-row-link" href="${detailHref}">${escapeHtml(threat.title)}</a></div>
           <div class="threat-row-source">${escapeHtml(threat.source)}</div>
+          <div class="tc-meta-line">${threat.models.length} model targets · ${threat.vectors.length} mapped vectors · ${threat.iocs.length} IOC${threat.iocs.length === 1 ? '' : 's'}</div>
         </div>
         <div class="tc-score-card">
           <span class="tc-score-label">Blended score</span>
@@ -81,14 +118,27 @@ function resultCard(threat) {
         </div>
       </div>
 
-      <div class="threat-row-meta">
-        <div class="tc-meta">
-          ${badge(threat.severity.toUpperCase(), severityClasses[threat.severity] ?? 'b-gray')}
-          ${badge(threat.status, statusClasses[threat.status] ?? 'b-gray')}
-          ${badge(threat.type, 'b-gray')}
-          ${threat.cve ? `<span class="ttp-tag">${escapeHtml(threat.cve)}</span>` : ''}
+      <div class="threat-row-scan">
+        <div class="threat-row-scan-item">
+          <span>Severity</span>
+          <strong>${escapeHtml(threat.severity.toUpperCase())}</strong>
+          <p>${escapeHtml(threat.status)} workflow state</p>
         </div>
-        <div class="tc-meta-line">Published ${formatDate(threat.publishedAt)} | Updated ${formatDate(threat.updatedAt)}</div>
+        <div class="threat-row-scan-item">
+          <span>Models</span>
+          <strong>${escapeHtml(topModels || 'None listed')}</strong>
+          <p>${threat.models.length} model family${threat.models.length === 1 ? '' : 'ies'} in scope</p>
+        </div>
+        <div class="threat-row-scan-item">
+          <span>Vectors</span>
+          <strong>${escapeHtml(topVectors || 'None listed')}</strong>
+          <p>${threat.vectors.length} delivery path${threat.vectors.length === 1 ? '' : 's'} tracked</p>
+        </div>
+        <div class="threat-row-scan-item">
+          <span>Age and patch</span>
+          <strong>${escapeHtml(ageLabel)}</strong>
+          <p>${patchLine}</p>
+        </div>
       </div>
 
       <div class="threat-row-summary">${escapeHtml(threat.description)}</div>


### PR DESCRIPTION
## Summary
- P5-01 strengthened Overview metric hierarchy so the critical KPI reads as the lead signal without widening into a dashboard redesign.
- P5-02 improved `/threats` scanability by moving filters directly into the results workflow and tightening row anatomy around severity, models, vectors, score, and age/patch context.
- P5-03 replaced bare dashboard loading text with restrained skeleton states on the most visible feeds.
- P5-04 hid SIEM from the current primary UX behind a recoverable feature flag and tightened workspace navigation copy.
- P5-05 completed the final regression sweep and refreshed README/issue tracking for the Phase V state.

## Validation
- `npm test`
- `npm run build`

## Notes
- Preserved the existing route structure and component foundation.
- Kept SIEM implementation recoverable without exposing it in the current primary workflow.