### PR TITLE
ThreatParallax runtime fixes for cron reliability and overview fetches

### DIFF
--- a/ISSUE_ORDER.md
+++ b/ISSUE_ORDER.md
@@ -77,3 +77,10 @@ ThreatParallax Phase I covers UI rebrand, visual-system cleanup, shell moderniza
    Note: Hid the SIEM workspace tab and panel behind a recoverable feature flag, then tightened the surrounding workspace copy so the primary UX stays focused on the active analyst surfaces.
 5. P5-05 [#35](https://github.com/nvrenuf/aitid/issues/35) Final regression sweep, docs touch-up, and PR polish - completed
    Note: Re-ran the final build/test pass, refreshed README for the Phase V analyst UX state, and prepared the branch as the single draft PR review surface for Phase V.
+
+## Runtime Fixes
+
+1. RF-01 [#38](https://github.com/nvrenuf/aitid/issues/38) Pipeline cron reliability and explicit route error handling - completed
+   Note: Reworked `/api/pipeline/run` around shared cron/manual request parsing, added explicit JSON responses and route-level error logging, and removed the current 503 path for valid Vercel cron GET requests when `CRON_SECRET` is absent.
+2. RF-02 [#39](https://github.com/nvrenuf/aitid/issues/39) Reduce duplicate overview stats and threats fetches - pending
+   Note: Reduce the confirmed duplicate `/api/stats` and `/api/threats` requests on `/overview` while preserving the current server-rendered route behavior.

--- a/ISSUE_ORDER.md
+++ b/ISSUE_ORDER.md
@@ -82,5 +82,5 @@ ThreatParallax Phase I covers UI rebrand, visual-system cleanup, shell moderniza
 
 1. RF-01 [#38](https://github.com/nvrenuf/aitid/issues/38) Pipeline cron reliability and explicit route error handling - completed
    Note: Reworked `/api/pipeline/run` around shared cron/manual request parsing, added explicit JSON responses and route-level error logging, and removed the current 503 path for valid Vercel cron GET requests when `CRON_SECRET` is absent.
-2. RF-02 [#39](https://github.com/nvrenuf/aitid/issues/39) Reduce duplicate overview stats and threats fetches - pending
-   Note: Reduce the confirmed duplicate `/api/stats` and `/api/threats` requests on `/overview` while preserving the current server-rendered route behavior.
+2. RF-02 [#39](https://github.com/nvrenuf/aitid/issues/39) Reduce duplicate overview stats and threats fetches - completed
+   Note: Confirmed that `/overview` was duplicating `/api/stats` work but not `/api/threats`, then hydrated the dashboard from the server-rendered stats payload so the initial stats request is no longer repeated on page load.

--- a/src/components/dashboard/OverviewPanel.astro
+++ b/src/components/dashboard/OverviewPanel.astro
@@ -23,6 +23,8 @@ const overviewStats = [
   { label: 'New this week', id: 'overview-week', value: initialStats.newThisWeek },
   { label: 'Tracked items', id: 'overview-total', value: initialStats.totalThreats },
 ];
+
+const initialStatsJson = JSON.stringify(initialStats);
 ---
 
 <div class="panel active" id="panel-overview">
@@ -113,6 +115,7 @@ const overviewStats = [
           <div class="loading-copy">Preparing current threats and score context.</div>
         </div>
       </div>
+      <script id="overview-initial-stats" type="application/json" set:html={initialStatsJson}></script>
     </div>
     <div class="resize-handle" id="sidebar-resize-handle"></div>
     <div class="sidebar" id="overview-sidebar" style="width:260px;min-width:160px;max-width:520px;overflow-y:auto;flex-shrink:0">

--- a/src/lib/pipeline-run-request.js
+++ b/src/lib/pipeline-run-request.js
@@ -1,0 +1,64 @@
+function getAuthorizationHeader(request) {
+  return request.headers.get('Authorization') ?? '';
+}
+
+export function isVercelCronRequest(request) {
+  const userAgent = request.headers.get('user-agent') ?? '';
+  return userAgent.includes('vercel-cron/1.0');
+}
+
+export function authorizePipelineRunRequest(request, cronSecret) {
+  const isCronRequest = isVercelCronRequest(request);
+  const authHeader = getAuthorizationHeader(request);
+
+  if (cronSecret) {
+    if (authHeader === `Bearer ${cronSecret}`) {
+      return {
+        ok: true,
+        authMode: 'cron-secret',
+        isCronRequest,
+      };
+    }
+
+    return {
+      ok: false,
+      status: 401,
+      error: 'Unauthorized',
+      authMode: 'rejected',
+      isCronRequest,
+    };
+  }
+
+  if (isCronRequest) {
+    return {
+      ok: true,
+      authMode: 'vercel-cron-user-agent',
+      isCronRequest,
+      warning: 'CRON_SECRET is not configured; allowing the Vercel cron user agent fallback.',
+    };
+  }
+
+  return {
+    ok: false,
+    status: 503,
+    error: 'CRON_SECRET is not configured',
+    authMode: 'rejected',
+    isCronRequest,
+  };
+}
+
+export async function readPipelineRunInput(request) {
+  if (request.method !== 'POST') {
+    return {
+      lookbackDays: 7,
+      forceReclassify: false,
+    };
+  }
+
+  const body = await request.json().catch(() => ({}));
+
+  return {
+    lookbackDays: Number(body.lookbackDays ?? 7),
+    forceReclassify: Boolean(body.forceReclassify ?? false),
+  };
+}

--- a/src/pages/api/pipeline/run.ts
+++ b/src/pages/api/pipeline/run.ts
@@ -4,63 +4,81 @@
 
 import type { APIRoute } from 'astro';
 import { runPipeline } from '../../../lib/pipeline.js';
+import { authorizePipelineRunRequest, readPipelineRunInput } from '../../../lib/pipeline-run-request.js';
+
+function jsonResponse(payload: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+async function handlePipelineRun(request: Request) {
+  const cronSecret = process.env.CRON_SECRET ?? '';
+  const authorization = authorizePipelineRunRequest(request, cronSecret);
+
+  if (!authorization.ok) {
+    console.warn('[/api/pipeline/run] Request rejected', {
+      method: request.method,
+      status: authorization.status,
+      error: authorization.error,
+      isCronRequest: authorization.isCronRequest,
+    });
+
+    return jsonResponse(
+      {
+        error: authorization.error,
+        isCronRequest: authorization.isCronRequest,
+      },
+      authorization.status,
+    );
+  }
+
+  if (authorization.warning) {
+    console.warn(`[/api/pipeline/run] ${authorization.warning}`);
+  }
+
+  try {
+    const { lookbackDays, forceReclassify } = await readPipelineRunInput(request);
+
+    console.log('[/api/pipeline/run] Starting pipeline run', {
+      method: request.method,
+      authMode: authorization.authMode,
+      isCronRequest: authorization.isCronRequest,
+      lookbackDays,
+      forceReclassify,
+    });
+
+    const run = await runPipeline({ lookbackDays, forceReclassify });
+
+    return jsonResponse({
+      ...run,
+      authMode: authorization.authMode,
+      isCronRequest: authorization.isCronRequest,
+    });
+  } catch (error) {
+    console.error('[/api/pipeline/run] Route failed before pipeline completion', error);
+
+    return jsonResponse(
+      {
+        error: 'Pipeline route failed before completion',
+        detail: error instanceof Error ? error.message : String(error),
+        authMode: authorization.authMode,
+        isCronRequest: authorization.isCronRequest,
+      },
+      500,
+    );
+  }
+}
 
 export const POST: APIRoute = async ({ request }) => {
-  // Auth check — Vercel sends Authorization header for cron jobs
-  const authHeader = request.headers.get('Authorization') ?? '';
-  const cronSecret = process.env.CRON_SECRET ?? '';
-  
-  if (!cronSecret) {
-    return new Response(JSON.stringify({ error: 'CRON_SECRET is not configured' }), {
-      status:  503,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
-  if (authHeader !== `Bearer ${cronSecret}`) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status:  401,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
-  const body = await request.json().catch(() => ({})) as Record<string, unknown>;
-  const lookbackDays   = Number(body.lookbackDays   ?? 7);
-  const forceReclassify = Boolean(body.forceReclassify ?? false);
-
-  console.log(`[/api/pipeline/run] Starting pipeline run (lookback: ${lookbackDays}d, force: ${forceReclassify})`);
-
-  // Run async — return immediately with run ID, pipeline continues
-  const runPromise = runPipeline({ lookbackDays, forceReclassify });
-
-  // For Vercel serverless we need to await (max 60s configured in vercel.json)
-  const run = await runPromise;
-
-  return new Response(JSON.stringify(run), {
-    status:  200,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  return handlePipelineRun(request);
 };
 
 // Also support GET for easy manual testing from browser
 export const GET: APIRoute = async ({ request }) => {
-  const authHeader = request.headers.get('Authorization') ?? '';
-  const cronSecret = process.env.CRON_SECRET ?? '';
-  if (!cronSecret) {
-    return new Response(JSON.stringify({ error: 'CRON_SECRET is not configured' }), {
-      status: 503,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-  if (authHeader !== `Bearer ${cronSecret}`) {
-    return new Response(JSON.stringify({ error: 'Use POST with Authorization header' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-  const run = await runPipeline({ lookbackDays: 7 });
-  return new Response(JSON.stringify(run), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  return handlePipelineRun(request);
 };

--- a/src/scripts/dashboard-client.js
+++ b/src/scripts/dashboard-client.js
@@ -12,6 +12,17 @@ let allThreats = [];
 let overviewFilter = 'all';
 let selectedThreatId = null;
 
+function readInitialOverviewStats() {
+  const raw = document.getElementById('overview-initial-stats')?.textContent;
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
 const severityClasses = {
   critical: 'b-crit',
   high: 'b-high',
@@ -395,6 +406,26 @@ function renderAll() {
   updateBadges();
 }
 
+function applyOverviewStats(stats) {
+  const statusText = stats.pipelineStatus === 'healthy' ? 'Collection healthy' : 'Collection needs review';
+  const updatedText = formatEasternTimestamp(stats.lastUpdated);
+
+  safeSetText('m-total', stats.totalThreats);
+  safeSetText('m-crit', stats.activeCritical);
+  safeSetText('m-week', stats.newThisWeek);
+  safeSetText('m-models', stats.modelsAffected);
+  safeSetText('m-total-d', stats.totalThreats > 0 ? `+ ${Math.max(1, Math.floor(stats.totalThreats * 0.25))} vs last week` : '');
+  safeSetText('m-crit-d', stats.activeCritical > 0 ? `+ ${stats.activeCritical} new today` : 'no active criticals');
+  safeSetText('m-week-d', 'steady vs prior');
+  safeSetText('m-models-d', 'distinct model tags in current corpus');
+  safeSetText('overview-status', statusText);
+  safeSetText('overview-updated', updatedText);
+  safeSetText('overview-critical', stats.activeCritical);
+  safeSetText('overview-models', stats.modelsAffected);
+  safeSetText('overview-week', stats.newThisWeek);
+  safeSetText('overview-total', stats.totalThreats);
+}
+
 async function loadThreats() {
   try {
     const response = await fetch('/api/threats');
@@ -410,23 +441,7 @@ async function loadStats() {
   try {
     const response = await fetch('/api/stats');
     const stats = await response.json();
-    const statusText = stats.pipelineStatus === 'healthy' ? 'Collection healthy' : 'Collection needs review';
-    const updatedText = formatEasternTimestamp(stats.lastUpdated);
-
-    safeSetText('m-total', stats.totalThreats);
-    safeSetText('m-crit', stats.activeCritical);
-    safeSetText('m-week', stats.newThisWeek);
-    safeSetText('m-models', stats.modelsAffected);
-    safeSetText('m-total-d', stats.totalThreats > 0 ? `+ ${Math.max(1, Math.floor(stats.totalThreats * 0.25))} vs last week` : '');
-    safeSetText('m-crit-d', stats.activeCritical > 0 ? `+ ${stats.activeCritical} new today` : 'no active criticals');
-    safeSetText('m-week-d', 'steady vs prior');
-    safeSetText('m-models-d', 'distinct model tags in current corpus');
-    safeSetText('overview-status', statusText);
-    safeSetText('overview-updated', updatedText);
-    safeSetText('overview-critical', stats.activeCritical);
-    safeSetText('overview-models', stats.modelsAffected);
-    safeSetText('overview-week', stats.newThisWeek);
-    safeSetText('overview-total', stats.totalThreats);
+    applyOverviewStats(stats);
   } catch {
     // Use server-rendered fallback values.
   }
@@ -651,5 +666,10 @@ initModelSubnavs();
 initVectorToggle();
 initClock();
 initResize();
-loadStats();
+const initialOverviewStats = readInitialOverviewStats();
+if (initialOverviewStats) {
+  applyOverviewStats(initialOverviewStats);
+} else {
+  loadStats();
+}
 loadThreats();

--- a/tests/pipeline-run-request.test.js
+++ b/tests/pipeline-run-request.test.js
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  authorizePipelineRunRequest,
+  isVercelCronRequest,
+  readPipelineRunInput,
+} from '../src/lib/pipeline-run-request.js';
+
+test('isVercelCronRequest detects the documented Vercel cron user agent', () => {
+  const request = new Request('https://example.com/api/pipeline/run', {
+    method: 'GET',
+    headers: {
+      'user-agent': 'vercel-cron/1.0',
+    },
+  });
+
+  assert.equal(isVercelCronRequest(request), true);
+});
+
+test('authorizePipelineRunRequest accepts Authorization header when CRON_SECRET is configured', () => {
+  const request = new Request('https://example.com/api/pipeline/run', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer top-secret',
+    },
+  });
+
+  assert.deepEqual(authorizePipelineRunRequest(request, 'top-secret'), {
+    ok: true,
+    authMode: 'cron-secret',
+    isCronRequest: false,
+  });
+});
+
+test('authorizePipelineRunRequest allows Vercel cron fallback when CRON_SECRET is absent', () => {
+  const request = new Request('https://example.com/api/pipeline/run', {
+    method: 'GET',
+    headers: {
+      'user-agent': 'vercel-cron/1.0',
+    },
+  });
+
+  const result = authorizePipelineRunRequest(request, '');
+
+  assert.equal(result.ok, true);
+  assert.equal(result.authMode, 'vercel-cron-user-agent');
+  assert.equal(result.isCronRequest, true);
+  assert.match(result.warning, /CRON_SECRET is not configured/);
+});
+
+test('authorizePipelineRunRequest rejects external requests when CRON_SECRET is absent', () => {
+  const request = new Request('https://example.com/api/pipeline/run', {
+    method: 'POST',
+  });
+
+  assert.deepEqual(authorizePipelineRunRequest(request, ''), {
+    ok: false,
+    status: 503,
+    error: 'CRON_SECRET is not configured',
+    authMode: 'rejected',
+    isCronRequest: false,
+  });
+});
+
+test('readPipelineRunInput defaults GET requests to the cron-safe payload', async () => {
+  const request = new Request('https://example.com/api/pipeline/run', {
+    method: 'GET',
+  });
+
+  assert.deepEqual(await readPipelineRunInput(request), {
+    lookbackDays: 7,
+    forceReclassify: false,
+  });
+});
+
+test('readPipelineRunInput parses POST body options', async () => {
+  const request = new Request('https://example.com/api/pipeline/run', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      lookbackDays: 14,
+      forceReclassify: true,
+    }),
+  });
+
+  assert.deepEqual(await readPipelineRunInput(request), {
+    lookbackDays: 14,
+    forceReclassify: true,
+  });
+});


### PR DESCRIPTION
## Summary
- fix `/api/pipeline/run` so valid Vercel cron GET requests no longer hit the route’s current `503` path when `CRON_SECRET` is absent
- centralize pipeline-run auth/input parsing and return explicit JSON responses with route-level logging on success and failure
- reduce confirmed duplicate `/api/stats` work on `/overview` by hydrating from the server-rendered stats payload instead of immediately re-fetching it on load
- leave `/api/threats` unchanged because the overview feed still fetches it only once and is not duplicating that request

## Validation
- `npm test`
- `npm run build`

## Notes
- Kept scope focused on runtime reliability and obvious fetch waste
- Preserved the existing route structure and current client-loaded overview feed behavior