### PR TITLE
Fix header refresh timestamp to use real feed update time

### DIFF
--- a/src/components/dashboard/DashboardShell.astro
+++ b/src/components/dashboard/DashboardShell.astro
@@ -2,7 +2,7 @@
 import { PRODUCT_ROUTES } from '../../lib/product-navigation.js';
 import { SHOW_SIEM_IN_PRIMARY_UX } from '../../lib/feature-flags.js';
 
-const { now, currentPath, routeMeta, showWorkspaceNav = false } = Astro.props;
+const { headerUpdatedLabel, currentPath, routeMeta, showWorkspaceNav = false } = Astro.props;
 
 const shellTabs = [
   { id: 'overview', label: 'Overview workspace', badgeId: 'badge-overview', badge: '--', active: true },
@@ -52,7 +52,7 @@ if (SHOW_SIEM_IN_PRIMARY_UX) {
   <div class="hdr-right">
     <div class="status-cluster">
       <div class="live-pill"><div class="pulse"></div>Live feed active · Updated:</div>
-      <div class="hdr-time" id="hdr-time">{now}</div>
+      <div class="hdr-time" id="hdr-time">{headerUpdatedLabel}</div>
     </div>
     <div class="surface-chips">
       <span class="future-chip"><strong>{routeMeta.label}</strong> · {routeMeta.kicker}</span>

--- a/src/components/layout/ProductLayout.astro
+++ b/src/components/layout/ProductLayout.astro
@@ -1,17 +1,26 @@
 ---
 import DashboardShell from '../dashboard/DashboardShell.astro';
 import { getRouteMeta } from '../../lib/product-navigation.js';
+import { getStats } from '../../lib/store.js';
+import { formatEasternRefreshTimestamp } from '../../lib/time.js';
 import '../../styles/threatparallax.css';
 
 const {
   title = 'ThreatParallax | AI Threat Intelligence Platform',
   description = 'ThreatParallax is an AI Threat Intelligence Platform for security leaders and analysts monitoring model-linked threats, exposure vectors, and operational risk.',
-  now,
   currentPath = '/overview',
   showWorkspaceNav = false,
 } = Astro.props;
 
 const routeMeta = getRouteMeta(currentPath);
+
+let headerUpdatedLabel = 'unavailable';
+try {
+  const stats = await getStats();
+  headerUpdatedLabel = formatEasternRefreshTimestamp(stats?.lastUpdated);
+} catch {
+  headerUpdatedLabel = 'unavailable';
+}
 ---
 
 <!DOCTYPE html>
@@ -299,7 +308,7 @@ const routeMeta = getRouteMeta(currentPath);
 </head>
 <body>
   <div id="app">
-    <DashboardShell now={now} currentPath={currentPath} routeMeta={routeMeta} showWorkspaceNav={showWorkspaceNav} />
+    <DashboardShell headerUpdatedLabel={headerUpdatedLabel} currentPath={currentPath} routeMeta={routeMeta} showWorkspaceNav={showWorkspaceNav} />
     <slot />
   </div>
 </body>

--- a/src/lib/overview-data.ts
+++ b/src/lib/overview-data.ts
@@ -1,6 +1,6 @@
 import { SEED_THREATS } from './seed.js';
 import { getStats } from './store.js';
-import { formatEasternTime, formatEasternTimestamp } from './time.js';
+import { formatEasternTimestamp } from './time.js';
 
 export async function getOverviewPageData() {
   let stats;
@@ -42,6 +42,5 @@ export async function getOverviewPageData() {
     overviewPriority,
     overviewStatus,
     overviewUpdated,
-    now: formatEasternTime(),
   };
 }

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -44,3 +44,12 @@ export function formatEasternTimestamp(value) {
 export function formatEasternDate(value) {
   return easternDateFormatter.format(toDate(value));
 }
+
+export function formatEasternRefreshTimestamp(value) {
+  if (!value) return 'unavailable';
+
+  const date = toDate(value);
+  if (Number.isNaN(date.getTime())) return 'unavailable';
+
+  return formatEasternTimestamp(date);
+}

--- a/src/pages/overview.astro
+++ b/src/pages/overview.astro
@@ -7,7 +7,7 @@ import { getOverviewPageData } from '../lib/overview-data.js';
 const overviewData = await getOverviewPageData();
 ---
 
-<ProductLayout now={overviewData.now} currentPath="/overview" showWorkspaceNav={true}>
+<ProductLayout currentPath="/overview" showWorkspaceNav={true}>
   <OverviewWorkspace {...overviewData} />
   <ThreatDetailDrawer />
 

--- a/src/pages/research.astro
+++ b/src/pages/research.astro
@@ -1,11 +1,8 @@
 ---
 import ProductLayout from '../components/layout/ProductLayout.astro';
 import ResearchSurface from '../components/research/ResearchSurface.astro';
-import { formatEasternTime } from '../lib/time.js';
-
-const now = formatEasternTime();
 ---
 
-<ProductLayout now={now} currentPath="/research">
+<ProductLayout currentPath="/research">
   <ResearchSurface />
 </ProductLayout>

--- a/src/pages/threat-map.astro
+++ b/src/pages/threat-map.astro
@@ -2,12 +2,10 @@
 import ProductLayout from '../components/layout/ProductLayout.astro';
 import ThreatMapSurface from '../components/threat-map/ThreatMapSurface.astro';
 import { getThreatMapDataset } from '../lib/threat-map.js';
-import { formatEasternTime } from '../lib/time.js';
 
-const now = formatEasternTime();
 const dataset = await getThreatMapDataset();
 ---
 
-<ProductLayout now={now} currentPath="/threat-map">
+<ProductLayout currentPath="/threat-map">
   <ThreatMapSurface dataset={dataset} />
 </ProductLayout>

--- a/src/pages/threats.astro
+++ b/src/pages/threats.astro
@@ -2,14 +2,11 @@
 import ProductLayout from '../components/layout/ProductLayout.astro';
 import ThreatsSurface from '../components/threats/ThreatsSurface.astro';
 import { getThreatSurfaceData } from '../lib/threats.js';
-import { formatEasternTime } from '../lib/time.js';
 
-const now = formatEasternTime();
 const threatSurfaceData = await getThreatSurfaceData();
 ---
 
 <ProductLayout
-  now={now}
   currentPath="/threats"
   title="ThreatParallax Threats | AI Threat Intelligence Platform"
   description="ThreatParallax Threats provides a dedicated operator workflow for scanning the current AI threat corpus by severity, model, vector, status, and search."

--- a/src/pages/threats/[slug].astro
+++ b/src/pages/threats/[slug].astro
@@ -2,9 +2,7 @@
 import ProductLayout from '../../components/layout/ProductLayout.astro';
 import ThreatDetailSurface from '../../components/threats/ThreatDetailSurface.astro';
 import { getThreatBySlug } from '../../lib/threats.js';
-import { formatEasternTime } from '../../lib/time.js';
 
-const now = formatEasternTime();
 const slug = Astro.params.slug ?? '';
 const threat = await getThreatBySlug(slug);
 
@@ -14,7 +12,6 @@ if (!threat) {
 ---
 
 <ProductLayout
-  now={now}
   currentPath="/threats"
   title={threat ? `${threat.title} | ThreatParallax` : 'Threat not found | ThreatParallax'}
   description={threat ? threat.description : 'The requested threat record could not be found in the current ThreatParallax corpus.'}

--- a/src/scripts/dashboard-client.js
+++ b/src/scripts/dashboard-client.js
@@ -6,7 +6,7 @@ import {
   sortThreats,
 } from '../lib/dashboard-utils.js';
 import { getThreatDetailHref } from '../lib/threats-utils.js';
-import { formatEasternDate, formatEasternTime, formatEasternTimestamp } from '../lib/time.js';
+import { formatEasternDate, formatEasternRefreshTimestamp, formatEasternTimestamp } from '../lib/time.js';
 
 let allThreats = [];
 let overviewFilter = 'all';
@@ -409,6 +409,7 @@ function renderAll() {
 function applyOverviewStats(stats) {
   const statusText = stats.pipelineStatus === 'healthy' ? 'Collection healthy' : 'Collection needs review';
   const updatedText = formatEasternTimestamp(stats.lastUpdated);
+  const headerUpdatedText = formatEasternRefreshTimestamp(stats.lastUpdated);
 
   safeSetText('m-total', stats.totalThreats);
   safeSetText('m-crit', stats.activeCritical);
@@ -420,6 +421,7 @@ function applyOverviewStats(stats) {
   safeSetText('m-models-d', 'distinct model tags in current corpus');
   safeSetText('overview-status', statusText);
   safeSetText('overview-updated', updatedText);
+  safeSetText('hdr-time', headerUpdatedText);
   safeSetText('overview-critical', stats.activeCritical);
   safeSetText('overview-models', stats.modelsAffected);
   safeSetText('overview-week', stats.newThisWeek);
@@ -609,12 +611,6 @@ function saveSiemConfig() {
   alert('SIEM config saved. Set SIEM_TYPE, SIEM_WEBHOOK_URL, SIEM_SECRET, and SIEM_MIN_SEVERITY in your Vercel environment variables to activate live forwarding.');
 }
 
-function initClock() {
-  window.setInterval(() => {
-    safeSetText('hdr-time', formatEasternTime());
-  }, 30000);
-}
-
 function initResize() {
   const handle = document.getElementById('sidebar-resize-handle');
   const sidebar = document.getElementById('overview-sidebar');
@@ -664,7 +660,6 @@ initOverviewFilters();
 initThreatInteractions();
 initModelSubnavs();
 initVectorToggle();
-initClock();
 initResize();
 const initialOverviewStats = readInitialOverviewStats();
 if (initialOverviewStats) {

--- a/tests/time.test.js
+++ b/tests/time.test.js
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { formatEasternDate, formatEasternTime, formatEasternTimestamp } from '../src/lib/time.js';
+import {
+  formatEasternDate,
+  formatEasternRefreshTimestamp,
+  formatEasternTime,
+  formatEasternTimestamp,
+} from '../src/lib/time.js';
 
 test('formatEasternTime uses EST during standard time', () => {
   assert.equal(
@@ -22,4 +27,16 @@ test('formatEasternDate keeps date-only rendering pinned to Eastern Time', () =>
     formatEasternDate('2026-07-15T02:30:00Z'),
     'Jul 14, 2026',
   );
+});
+
+test('formatEasternRefreshTimestamp matches the canonical header shape', () => {
+  assert.equal(
+    formatEasternRefreshTimestamp('2026-03-27T04:15:00Z'),
+    'Mar 27, 12:15 AM EDT',
+  );
+});
+
+test('formatEasternRefreshTimestamp falls back to unavailable when no real timestamp exists', () => {
+  assert.equal(formatEasternRefreshTimestamp(undefined), 'unavailable');
+  assert.equal(formatEasternRefreshTimestamp('not-a-date'), 'unavailable');
 });


### PR DESCRIPTION
## Summary
- replace the header’s ticking/current-time behavior with the real last successful feed refresh timestamp
- bind the header timestamp to the existing dashboard stats source of truth (`lastUpdated`)
- format the header in canonical Eastern Time with DST-aware `EST`/`EDT`
- show `unavailable` when no real refresh timestamp exists instead of substituting the current time

## Validation
- `npm test`
- `npm run build`