### PR TITLE
ThreatParallax design pass 1: mockups and implementation brief

### DIFF
--- a/DESIGN_REVIEW_BRIEF.md
+++ b/DESIGN_REVIEW_BRIEF.md
@@ -1,0 +1,79 @@
+# ThreatParallax Design Review Brief
+
+## Current weaknesses
+
+- The top of the Overview page spends too much vertical space on explanatory copy before the product state is visible.
+- KPI treatment has improved, but it still reads more like dashboard scaffolding than a premium product surface.
+- Supporting blocks often feel assembled rather than composed; spacing, alignment, and grouping are not yet disciplined enough.
+- Several labels and helper phrases are accurate but visually low-value, which slows scanning and weakens seriousness.
+- Threat cards contain the right information, but the hierarchy is not crisp enough for fast operator review.
+- The Threat Map still feels closer to a demo visualization than a trustworthy intelligence surface.
+- Detail pages are informative, but they do not yet feel authoritative enough to function as shareable intelligence records.
+
+## Target visual direction
+
+- Keep the ThreatParallax dark palette and threat-intelligence identity, but refine it into a calmer and more product-grade system.
+- Shift the product tone toward restrained intelligence software: compact, deliberate, serious, and trustworthy.
+- Make typography hierarchy do more work so pages can carry more information with less prose.
+- Use spacing and grouping to create clear scan paths: posture first, then analyst context, then drill-down detail.
+- Replace decorative dashboard energy with sober density, better alignment, and fewer competing highlights.
+- Treat charts, KPIs, filters, and side rails as one coordinated system rather than separate component islands.
+
+## Page-by-page goals
+
+### Overview
+
+- Compress the hero into a short posture statement plus utility chips.
+- Fold KPIs into the main composition so they feel intentional and premium.
+- Group trend, watchlist, and supporting context into a clear leadership-to-analyst scan path.
+- Reduce helper text and remove explanatory phrasing that repeats what the page already shows.
+
+### Threat Map
+
+- Present geography with more restraint and credibility.
+- Make the map feel analytical rather than illustrative or demo-like.
+- Tighten the filter bar and integrate it into the same surface as the map.
+- Recompose the regional detail panel so it reads like an intelligence brief.
+- Keep map limitations explicit, but phrase them more tightly.
+
+### Threats
+
+- Make filters feel embedded in the workflow rather than wrapped in explanatory chrome.
+- Increase scanability of result rows through stronger title emphasis and tighter metadata rhythm.
+- Keep density high without making the surface noisy.
+- Ensure the page feels like an operator workbench, not a generic feed.
+
+### Threat detail
+
+- Make the page feel like a serious canonical record that can be linked internally or shown externally.
+- Elevate source transparency, methodology, and confidence framing.
+- Separate evidence, operational readout, and response guidance more clearly.
+- Reduce any phrasing that sounds like filler or defensive narration.
+
+## What to simplify or remove
+
+- Overlong introductory paragraphs in prime page real estate.
+- Helper copy that repeats obvious UI meaning.
+- Labels that do not change decisions or interpretation.
+- Decorative treatment on the map that reads as “demo dashboard.”
+- Visually equivalent blocks that compete for attention without a clear hierarchy.
+
+## What to emphasize
+
+- Clear posture statements.
+- Stronger, fewer, more meaningful KPI cards.
+- Record titles, severity, score, and next action on operator surfaces.
+- Source discipline and confidence framing on detail surfaces.
+- Conservative map meaning and regional brief quality on the geography surface.
+- Tighter chip, badge, and metadata language.
+
+## Design rules for implementation
+
+1. Keep the existing ThreatParallax palette and route structure; refine, do not replace.
+2. Prefer short, useful labels over helper prose.
+3. Compress top-of-page compositions before adding any new content modules.
+4. Use one spacing and card system across all four pages.
+5. Reserve strong highlight treatments for true priority states only.
+6. Make side panels feel integrated into the page composition, not bolted on.
+7. Treat map visuals as evidence framing, not decorative spectacle.
+8. Bias toward executive clarity first, analyst depth second, and explanatory copy last.

--- a/REVIEW_NOTES.md
+++ b/REVIEW_NOTES.md
@@ -1,0 +1,35 @@
+# ThreatParallax Review Notes
+
+## Key differences from the current product
+
+- The top compositions are materially shorter and more decisive, especially on Overview.
+- KPI cards are calmer and more premium, with fewer competing accents.
+- Filters are integrated into page workflows instead of living inside explanatory sections.
+- Threat rows use stronger title hierarchy and tighter metadata grouping for faster scanability.
+- The map surface is more restrained, with cleaner node language and a more serious regional detail rail.
+- The detail page is restructured into a clearer intelligence record with explicit source and methodology sections.
+
+## Why these changes improve professionalism and usability
+
+- Shorter top sections get users to product state faster and reduce the feeling of reading through setup copy.
+- Stronger hierarchy makes it easier to distinguish posture, priority, and supporting context.
+- Reduced microcopy lowers cognitive load and removes the “internal dashboard” tone.
+- A more disciplined map presentation increases trust by avoiding visual language that feels speculative or theatrical.
+- Cleaner threat rows support operator scanning without flattening the importance of severity or score.
+- A more formal detail page improves shareability and makes the product feel safer for buyer-facing review.
+
+## What should be implemented first
+
+1. Overview top composition and KPI system.
+2. Shared spacing, card, badge, and typography rules across all four target pages.
+3. Threat row hierarchy and integrated filter treatment on the Threats page.
+4. Threat detail record structure, especially source transparency and methodology framing.
+5. Threat Map stage and regional detail rail redesign.
+
+## What can wait
+
+- Secondary chart refinements beyond the core trend and watchlist groupings.
+- Additional motion or transitions.
+- Any expansion of research-route depth.
+- New data dimensions that are not already part of the current product model.
+- Advanced map interaction beyond the improved static composition and detail behavior.

--- a/src/components/design-review/ReviewLayout.astro
+++ b/src/components/design-review/ReviewLayout.astro
@@ -1,0 +1,94 @@
+---
+import '../../styles/design-review.css';
+
+const {
+  title = 'ThreatParallax Design Review',
+  pageTitle = 'Design review',
+  pageSummary = 'Static design-direction prototypes for ThreatParallax.',
+  currentPage = 'index',
+} = Astro.props;
+
+const pages = [
+  { id: 'index', href: '/design-review', label: 'Review hub', kicker: 'Context' },
+  { id: 'overview', href: '/design-review/overview', label: 'Overview', kicker: 'Executive surface' },
+  { id: 'threat-map', href: '/design-review/threat-map', label: 'Threat Map', kicker: 'Geography surface' },
+  { id: 'threats', href: '/design-review/threats', label: 'Threats', kicker: 'Operator surface' },
+  { id: 'threat-detail', href: '/design-review/threat-detail', label: 'Threat detail', kicker: 'Record page' },
+];
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{title}</title>
+  <meta name="description" content={pageSummary} />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Manrope:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <div class="review-app">
+    <div class="review-shell">
+      <header class="review-header">
+        <div class="review-brand">
+          <div class="review-brand-mark" aria-hidden="true">
+            <svg viewBox="0 0 14 14" fill="none">
+              <rect x="1" y="1" width="5" height="5" rx="1" fill="#ff7a7a" />
+              <rect x="8" y="1" width="5" height="5" rx="1" fill="#ffb36d" opacity=".78" />
+              <rect x="1" y="8" width="5" height="5" rx="1" fill="#8ec5ff" opacity=".82" />
+              <rect x="8" y="8" width="5" height="5" rx="1" fill="#55d39f" opacity=".74" />
+            </svg>
+          </div>
+          <div class="review-brand-copy">
+            <div class="review-eyebrow">ThreatParallax design review</div>
+            <div class="review-brand-title">Mockups and implementation alignment</div>
+            <div class="review-brand-sub">Static prototypes only. No production routes modified.</div>
+          </div>
+        </div>
+        <div class="review-header-meta">
+          <div class="review-pill"><strong>Mode</strong> static mockups</div>
+          <div class="review-pill"><strong>Intent</strong> executive + analyst polish</div>
+          <div class="review-pill"><strong>Scope</strong> review before build phase</div>
+        </div>
+      </header>
+
+      <div class="review-body">
+        <aside class="review-nav">
+          <div>
+            <div class="review-eyebrow">Prototype pages</div>
+            <div class="review-nav-links">
+              {
+                pages.map((page) => (
+                  <a class:list={['review-nav-link', currentPage === page.id && 'active']} href={page.href}>
+                    <span class="review-kicker">{page.kicker}</span>
+                    <strong>{page.label}</strong>
+                  </a>
+                ))
+              }
+            </div>
+          </div>
+          <div class="review-nav-note">
+            These pages deliberately refine the current ThreatParallax identity rather than replacing it.
+            The goal is a calmer, more deliberate intelligence-product system with stronger composition and less filler.
+          </div>
+        </aside>
+
+        <main class="review-content">
+          <section class="review-page-header">
+            <div>
+              <div class="review-eyebrow">Design pass 1</div>
+              <h1>{pageTitle}</h1>
+              <p>{pageSummary}</p>
+            </div>
+            <div class="review-meta">Seeded content only · isolated review area</div>
+          </section>
+
+          <slot />
+        </main>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/src/pages/design-review/index.astro
+++ b/src/pages/design-review/index.astro
@@ -1,0 +1,106 @@
+---
+import ReviewLayout from '../../components/design-review/ReviewLayout.astro';
+---
+
+<ReviewLayout
+  title="ThreatParallax Design Review Hub"
+  currentPage="index"
+  pageTitle="ThreatParallax design review hub"
+  pageSummary="A self-contained area for reviewing the new visual direction, page compositions, and implementation intent before any production redesign work begins."
+>
+  <section class="review-grid two-col">
+    <div class="review-hero-card">
+      <div class="review-hero-top">
+        <div class="review-hero-copy">
+          <div class="review-eyebrow">Purpose</div>
+          <h2 class="review-hero-title">Professionalize the product without losing its threat-intelligence identity.</h2>
+          <p>
+            This pass tightens hierarchy, spacing, and component discipline across the four key surfaces.
+            It keeps the ThreatParallax palette and route structure, but treats the product more like a serious
+            intelligence platform than an organically growing internal dashboard.
+          </p>
+          <div class="review-chip-row">
+            <span class="review-chip">compressed top composition</span>
+            <span class="review-chip">premium KPI treatment</span>
+            <span class="review-chip">faster operator scanning</span>
+            <span class="review-chip">more trustworthy map language</span>
+          </div>
+        </div>
+        <div class="review-hero-rail">
+          <div class="review-summary-card">
+            <div class="review-label">Artifacts</div>
+            <div class="review-stat-value">6</div>
+            <p class="review-summary-copy">Two review docs plus four static route mockups under `src/pages/design-review/*`.</p>
+          </div>
+          <div class="review-summary-card">
+            <div class="review-label">Implementation posture</div>
+            <div class="review-stat-value">0</div>
+            <p class="review-summary-copy">No live route wiring, no backend changes, and no production component redesign in this pass.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="review-sidebar-card">
+      <div class="review-card-header">
+        <div>
+          <div class="review-label">Review flow</div>
+          <h2 class="review-card-title">What to inspect first</h2>
+        </div>
+      </div>
+      <div class="review-list">
+        <div class="review-list-item" style="padding:14px;">
+          <strong>DESIGN_REVIEW_BRIEF.md</strong>
+          <p class="review-list-copy">Direction, priorities, simplifications, and implementation rules.</p>
+        </div>
+        <div class="review-list-item" style="padding:14px;">
+          <strong><a href="/design-review/overview">Overview mockup</a></strong>
+          <p class="review-list-copy">Best single page to evaluate the new hierarchy and density model.</p>
+        </div>
+        <div class="review-list-item" style="padding:14px;">
+          <strong><a href="/design-review/threat-map">Threat Map mockup</a></strong>
+          <p class="review-list-copy">Tests whether the product can present geography with more trust and restraint.</p>
+        </div>
+        <div class="review-list-item" style="padding:14px;">
+          <strong>REVIEW_NOTES.md</strong>
+          <p class="review-list-copy">Explains the deltas from the current app and the recommended order of implementation.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="review-grid three-col">
+    <div class="review-card">
+      <div class="review-label">Overview</div>
+      <h2 class="review-card-title">Compressed executive posture</h2>
+      <p class="review-card-copy">Shorter top block, calmer KPI strip, and clearer grouping between posture, trend, and active watchlist.</p>
+      <a class="review-filter-action" href="/design-review/overview">Open overview mockup</a>
+    </div>
+    <div class="review-card">
+      <div class="review-label">Threat Map</div>
+      <h2 class="review-card-title">Trustworthy geography surface</h2>
+      <p class="review-card-copy">A more sober map stage, stronger regional detail rail, and fewer decorative affordances that read like demo UI.</p>
+      <a class="review-filter-action" href="/design-review/threat-map">Open threat map mockup</a>
+    </div>
+    <div class="review-card">
+      <div class="review-label">Threats</div>
+      <h2 class="review-card-title">Operator-first scanability</h2>
+      <p class="review-card-copy">Integrated filters, denser results, and more legible record structure for rapid triage.</p>
+      <a class="review-filter-action" href="/design-review/threats">Open threats mockup</a>
+    </div>
+  </section>
+
+  <section class="review-card">
+    <div class="review-card-header">
+      <div>
+        <div class="review-label">Threat detail</div>
+        <h2 class="review-card-title">Link-worthy intelligence record</h2>
+      </div>
+      <a class="review-filter-action" href="/design-review/threat-detail">Open threat detail mockup</a>
+    </div>
+    <p class="review-card-copy">
+      The detail page mockup reframes evidence, source transparency, methodology, and response guidance into
+      a more buyer-safe record page with stronger legal and operational credibility.
+    </p>
+  </section>
+</ReviewLayout>

--- a/src/pages/design-review/overview.astro
+++ b/src/pages/design-review/overview.astro
@@ -1,0 +1,185 @@
+---
+import ReviewLayout from '../../components/design-review/ReviewLayout.astro';
+
+const kpis = [
+  { label: 'Critical active', value: '4', tone: 'critical', note: 'Noisy but bounded to two active clusters.' },
+  { label: 'New in seven days', value: '9', tone: 'info', note: 'Cadence remains elevated across model supply chain.' },
+  { label: 'Models in scope', value: '11', tone: '', note: 'Tracked families with current exposure relevance.' },
+  { label: 'Collection health', value: 'Healthy', tone: 'low', note: 'Refresh lag within expected collection window.' },
+];
+
+const watchlist = [
+  {
+    title: 'Inference endpoint takeover via poisoned orchestration package',
+    severity: 'critical',
+    type: 'supply chain',
+    score: '9.4',
+    summary: 'Privilege handoff risk remains the highest-confidence issue in the current corpus after new package propagation evidence.',
+  },
+  {
+    title: 'Prompt-chain jailbreak bypassing internal guardrail scaffolding',
+    severity: 'high',
+    type: 'jailbreak',
+    score: '8.1',
+    summary: 'Operational relevance remains high because bypass paths map to widely reused orchestration patterns.',
+  },
+  {
+    title: 'Training artifact leak through model-serving debug residue',
+    severity: 'high',
+    type: 'data exposure',
+    score: '7.8',
+    summary: 'Active because downstream snapshots still expose fragments of sensitive intermediate artifacts.',
+  },
+];
+---
+
+<ReviewLayout
+  title="ThreatParallax Design Review - Overview"
+  currentPage="overview"
+  pageTitle="Overview mockup"
+  pageSummary="A tighter executive-and-analyst landing surface with a compressed header, calmer KPI treatment, and clearer grouping of posture, trend, and active review."
+>
+  <section class="review-hero-card">
+    <div class="review-hero-top">
+      <div class="review-hero-copy">
+        <div class="review-eyebrow">Overview surface</div>
+        <h2 class="review-hero-title">Current AI threat posture without the oversized intro block.</h2>
+        <p>
+          The hero is reduced to one decisive sentence, two utility chips, and an immediate posture statement.
+          KPI cards become part of the same composition instead of feeling like a separate dashboard band.
+        </p>
+        <div class="review-chip-row">
+          <span class="review-chip">collection healthy</span>
+          <span class="review-chip">updated 14m ago</span>
+          <span class="review-chip">executive + analyst workspace</span>
+        </div>
+      </div>
+
+      <div class="review-hero-rail">
+        <div class="review-summary-card">
+          <div class="review-label">Priority posture</div>
+          <div class="review-stat-value">Guarded</div>
+          <p class="review-summary-copy">Critical pressure is narrow but the surrounding supply-chain context still warrants elevated review discipline.</p>
+        </div>
+        <div class="review-summary-card">
+          <div class="review-label">Primary question</div>
+          <p class="review-summary-copy">Which active items can change defensive posture this week, and which belong in deeper analyst follow-up only?</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="review-grid kpi-grid">
+      {
+        kpis.map((kpi) => (
+          <div class:list={['review-kpi', kpi.tone]}>
+            <div class="review-stat-label">{kpi.label}</div>
+            <div class="review-kpi-value">{kpi.value}</div>
+            <p class="review-summary-copy">{kpi.note}</p>
+          </div>
+        ))
+      }
+    </div>
+  </section>
+
+  <section class="review-grid two-col">
+    <div class="review-band">
+      <div class="review-band-header">
+        <div>
+          <div class="review-label">Posture trend</div>
+          <h2 class="review-section-title">Pressure stays elevated, but concentrated.</h2>
+        </div>
+        <div class="review-meta">8 week volume with critical overlay</div>
+      </div>
+      <div class="review-chart">
+        <div class="review-chart-bars">
+          <div class="review-chart-bar" style="height:33%;"></div>
+          <div class="review-chart-bar" style="height:48%;"></div>
+          <div class="review-chart-bar" style="height:42%;"></div>
+          <div class="review-chart-bar critical" style="height:72%;"></div>
+          <div class="review-chart-bar" style="height:58%;"></div>
+          <div class="review-chart-bar" style="height:54%;"></div>
+          <div class="review-chart-bar critical" style="height:80%;"></div>
+          <div class="review-chart-bar" style="height:61%;"></div>
+        </div>
+      </div>
+      <div class="review-intel-grid">
+        <div class="review-mini-card">
+          <div class="review-mini-label">Dominant vector</div>
+          <strong>Supply chain / model extension path</strong>
+          <p class="review-summary-copy">The most impactful current items involve software or orchestration layers around the models, not just direct prompt abuse.</p>
+        </div>
+        <div class="review-mini-card">
+          <div class="review-mini-label">Leadership framing</div>
+          <strong>Escalate only posture-changing items</strong>
+          <p class="review-summary-copy">Low-value narrative copy is removed. The page now says what matters and gets out of the way.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="review-sidebar-card">
+      <div class="review-card-header">
+        <div>
+          <div class="review-label">Watchlist</div>
+          <h2 class="review-card-title">Active items worth immediate review</h2>
+        </div>
+      </div>
+      <div class="review-list">
+        {
+          watchlist.map((item) => (
+            <div class="review-feed-item">
+              <div class="review-feed-head">
+                <div>
+                  <div class="review-badge-row">
+                    <span class:list={['review-badge', item.severity]}>{item.severity}</span>
+                    <span class="review-badge neutral">{item.type}</span>
+                  </div>
+                  <div class="review-feed-title" style="margin-top:10px;">{item.title}</div>
+                </div>
+                <div class="review-score">
+                  <div class="review-mini-label">score</div>
+                  <div class="review-score-value">{item.score}</div>
+                </div>
+              </div>
+              <p class="review-card-copy">{item.summary}</p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <section class="review-split">
+    <div class="review-stage-card">
+      <div class="review-card-header">
+        <div>
+          <div class="review-label">Analyst lane</div>
+          <h2 class="review-card-title">Grouped evidence panels instead of floating blocks</h2>
+        </div>
+        <div class="review-meta">Trend, vectors, and model pressure align to one grid</div>
+      </div>
+      <div class="review-detail-grid">
+        <div class="review-mini-card">
+          <div class="review-mini-label">Model concentration</div>
+          <strong>OpenAI, Claude, and OSS serve most of the current attention load.</strong>
+          <p class="review-summary-copy">The composition moves from scattered utility blocks toward one intentional scan path.</p>
+        </div>
+        <div class="review-mini-card">
+          <div class="review-mini-label">Collection note</div>
+          <strong>Uncorroborated geography stays off-map.</strong>
+          <p class="review-summary-copy">Scope boundaries are kept visible, but phrased more tightly and with less helper noise.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="review-note">
+      <div class="review-label">Design intent</div>
+      <p class="review-summary-copy">
+        The overview mockup turns the top of the page into a compact leadership read, then hands off to analyst context.
+        It keeps density, but stops asking the user to parse multiple explanatory paragraphs before seeing the product state.
+      </p>
+      <p class="review-footer-note">
+        The live overview currently has the right information categories. This mockup mostly changes hierarchy, spacing, copy discipline, and component orchestration.
+      </p>
+    </div>
+  </section>
+</ReviewLayout>

--- a/src/pages/design-review/threat-detail.astro
+++ b/src/pages/design-review/threat-detail.astro
@@ -1,0 +1,184 @@
+---
+import ReviewLayout from '../../components/design-review/ReviewLayout.astro';
+
+const sources = [
+  {
+    title: 'Primary advisory',
+    detail: 'Vendor advisory with affected versions, remediation guidance, and package trust-path details.',
+  },
+  {
+    title: 'Independent validation',
+    detail: 'Research follow-up confirming the orchestration-layer privilege handoff and credential capture pathway.',
+  },
+  {
+    title: 'Internal normalization',
+    detail: 'ThreatParallax record mapping into severity, vectors, TTPs, patch posture, and confidence framing.',
+  },
+];
+
+const methods = [
+  {
+    title: 'Evidence standard',
+    detail: 'Only direct source material and defensible follow-up evidence are included. Uncorroborated geography and actor claims stay out.',
+  },
+  {
+    title: 'Score context',
+    detail: 'The blended score is treated as prioritization support, not a substitute for source review or operational judgment.',
+  },
+  {
+    title: 'Confidence framing',
+    detail: 'The page distinguishes between what is directly supported, what is normalized, and what remains unknown.',
+  },
+];
+---
+
+<ReviewLayout
+  title="ThreatParallax Design Review - Threat Detail"
+  currentPage="threat-detail"
+  pageTitle="Threat detail mockup"
+  pageSummary="A more serious record page with stronger source transparency, tighter metadata, and clearer separation between evidence, methodology, and action."
+>
+  <section class="review-detail-hero">
+    <div class="review-hero-card">
+      <div class="review-record-head">
+        <div>
+          <div class="review-eyebrow">Canonical threat record</div>
+          <h2 class="review-record-title">Inference endpoint takeover via poisoned orchestration package</h2>
+          <p class="review-card-copy" style="margin-top:12px;">
+            The record page is recast as a trustworthy intelligence artifact. It trims filler phrases and puts
+            evidence, source discipline, and operational takeaways into explicit, link-worthy sections.
+          </p>
+        </div>
+        <div class="review-score">
+          <div class="review-mini-label">blended score</div>
+          <div class="review-score-value">9.4</div>
+        </div>
+      </div>
+
+      <div class="review-badge-row">
+        <span class="review-badge critical">critical</span>
+        <span class="review-badge neutral">active</span>
+        <span class="review-badge neutral">supply chain</span>
+        <span class="review-badge neutral">CVE-2026-1442</span>
+      </div>
+
+      <div class="review-metadata-grid">
+        <div class="review-metadata-item">
+          <div class="review-mini-label">Published</div>
+          <p>March 24, 2026</p>
+        </div>
+        <div class="review-metadata-item">
+          <div class="review-mini-label">Source</div>
+          <p>JFrog advisory</p>
+        </div>
+        <div class="review-metadata-item">
+          <div class="review-mini-label">Patch posture</div>
+          <p>Patched in 4.2.1</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="review-record-rail">
+      <div class="review-summary-card">
+        <div class="review-label">Review framing</div>
+        <p class="review-summary-copy">This is a buyer-safe record page: direct enough to share internally, restrained enough to stand behind externally.</p>
+      </div>
+      <div class="review-summary-card">
+        <div class="review-label">Affected scope</div>
+        <p class="review-summary-copy">OpenAI, Claude, and OSS deployment workflows where the orchestration package sits in the model-serving path.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="review-grid two-col">
+    <div class="review-detail-panel">
+      <div class="review-detail-head">
+        <div>
+          <div class="review-label">Source transparency</div>
+          <h2 class="review-detail-title">Evidence is first-class, not buried.</h2>
+        </div>
+      </div>
+      <div class="review-source-list">
+        {
+          sources.map((source) => (
+            <div class="review-source-item">
+              <strong>{source.title}</strong>
+              <p>{source.detail}</p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+
+    <div class="review-detail-panel">
+      <div class="review-detail-head">
+        <div>
+          <div class="review-label">Operational read</div>
+          <h2 class="review-detail-title">What matters now</h2>
+        </div>
+      </div>
+      <div class="review-intel-grid">
+        <div class="review-mini-card">
+          <div class="review-mini-label">Immediate action</div>
+          <strong>Review orchestration dependencies and rotate compromised credentials.</strong>
+        </div>
+        <div class="review-mini-card">
+          <div class="review-mini-label">Exposure vector</div>
+          <strong>Package trust-path abuse near model-serving systems.</strong>
+        </div>
+        <div class="review-mini-card">
+          <div class="review-mini-label">Observed limits</div>
+          <strong>No actor-origin claim and no customer-telemetry assertion.</strong>
+        </div>
+        <div class="review-mini-card">
+          <div class="review-mini-label">Canonical route</div>
+          <strong>/threats/inference-endpoint-takeover</strong>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="review-grid two-col">
+    <div class="review-detail-panel">
+      <div class="review-detail-head">
+        <div>
+          <div class="review-label">Methodology</div>
+          <h2 class="review-detail-title">Normalization notes stay explicit</h2>
+        </div>
+      </div>
+      <div class="review-method-list">
+        {
+          methods.map((method) => (
+            <div class="review-method-item">
+              <strong>{method.title}</strong>
+              <p>{method.detail}</p>
+            </div>
+          ))
+        }
+      </div>
+    </div>
+
+    <div class="review-detail-panel">
+      <div class="review-detail-head">
+        <div>
+          <div class="review-label">Response guidance</div>
+          <h2 class="review-detail-title">Action and constraints separated cleanly</h2>
+        </div>
+      </div>
+      <div class="review-source-list">
+        <div class="review-source-item">
+          <strong>Mitigation</strong>
+          <p>Move to the patched package line, invalidate recently issued tokens, and inspect orchestration runners for unauthorized package replacement.</p>
+        </div>
+        <div class="review-source-item">
+          <strong>Residual risk</strong>
+          <p>Long-lived credentials and copied CI templates can keep this issue active after package remediation unless explicitly reviewed.</p>
+        </div>
+        <div class="review-source-item">
+          <strong>Confidence framing</strong>
+          <p>High confidence in the package abuse path, moderate confidence in total downstream spread, low confidence in broader geography conclusions.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</ReviewLayout>

--- a/src/pages/design-review/threat-map.astro
+++ b/src/pages/design-review/threat-map.astro
@@ -1,0 +1,209 @@
+---
+import ReviewLayout from '../../components/design-review/ReviewLayout.astro';
+
+const regions = [
+  { name: 'Western Europe', threats: '6', observations: '14', dominant: 'supply chain, credential theft' },
+  { name: 'US East', threats: '5', observations: '11', dominant: 'jailbreak, data exposure' },
+  { name: 'Singapore', threats: '3', observations: '5', dominant: 'infrastructure abuse' },
+];
+---
+
+<ReviewLayout
+  title="ThreatParallax Design Review - Threat Map"
+  currentPage="threat-map"
+  pageTitle="Threat Map mockup"
+  pageSummary="A more restrained geography surface that feels like a serious intelligence product: fewer decorative cues, stronger regional detail composition, and clearer trust boundaries."
+>
+  <section class="review-grid two-col">
+    <div class="review-hero-card">
+      <div class="review-hero-copy">
+        <div class="review-eyebrow">Threat Map surface</div>
+        <h2 class="review-hero-title">Observed geography presented like analysis, not like a demo globe.</h2>
+        <p>
+          The map becomes a sober projection panel with clean node treatment, reduced ornament, and a bottom caption
+          that clarifies meaning without over-explaining it. Filters are integrated into the same surface band.
+        </p>
+        <div class="review-chip-row">
+          <span class="review-chip">observed infrastructure only</span>
+          <span class="review-chip">coarse regional anchors</span>
+          <span class="review-chip">unmapped records kept explicit</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="review-grid three-col">
+      <div class="review-map-metric">
+        <div class="review-label">Mapped regions</div>
+        <strong>12</strong>
+        <span class="review-summary-copy">Conservative grouping, not exhaustive actor geography.</span>
+      </div>
+      <div class="review-map-metric">
+        <div class="review-label">Mapped threats</div>
+        <strong>18</strong>
+        <span class="review-summary-copy">Only records with defensible location evidence.</span>
+      </div>
+      <div class="review-map-metric">
+        <div class="review-label">Unmapped retained</div>
+        <strong>9</strong>
+        <span class="review-summary-copy">Coverage gaps stay visible instead of faked on the map.</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="review-band">
+    <div class="review-band-header">
+      <div>
+        <div class="review-label">Filter rail</div>
+        <h2 class="review-section-title">Operational filters sit inside the map workflow.</h2>
+      </div>
+      <div class="review-chip-row">
+        <span class="review-chip">critical</span>
+        <span class="review-chip">OpenAI + OSS</span>
+        <span class="review-chip">supply chain</span>
+      </div>
+    </div>
+    <div class="review-filter-grid">
+      <label class="review-filter-card">
+        <span class="review-filter-label">Search region or threat</span>
+        <input type="search" value="supply chain" />
+      </label>
+      <label class="review-filter-card">
+        <span class="review-filter-label">Severity</span>
+        <select><option>Critical</option></select>
+      </label>
+      <label class="review-filter-card">
+        <span class="review-filter-label">Model</span>
+        <select><option>OpenAI + OSS</option></select>
+      </label>
+      <label class="review-filter-card">
+        <span class="review-filter-label">Vector</span>
+        <select><option>Supply chain</option></select>
+      </label>
+      <label class="review-filter-card">
+        <span class="review-filter-label">Window</span>
+        <select><option>Current corpus</option></select>
+      </label>
+      <button class="review-filter-action" type="button">Reset</button>
+    </div>
+  </section>
+
+  <section class="review-map-layout">
+    <div class="review-map-card">
+      <div class="review-map-stage">
+        <svg viewBox="0 0 960 520" aria-label="Threat map mockup">
+          <g opacity="0.34" stroke="rgba(153, 178, 206, 0.16)" stroke-width="1">
+            <line x1="40" y1="120" x2="920" y2="120"></line>
+            <line x1="40" y1="220" x2="920" y2="220"></line>
+            <line x1="40" y1="320" x2="920" y2="320"></line>
+            <line x1="160" y1="60" x2="160" y2="420"></line>
+            <line x1="340" y1="60" x2="340" y2="420"></line>
+            <line x1="520" y1="60" x2="520" y2="420"></line>
+            <line x1="700" y1="60" x2="700" y2="420"></line>
+          </g>
+          <g fill="rgba(168, 202, 233, 0.14)" stroke="rgba(214, 228, 244, 0.16)" stroke-width="1.2">
+            <path d="M122 152c42-41 104-56 179-48 42 4 56 30 62 65-10 20-41 30-66 28-24-3-52 14-69 29-17 14-58 11-91-9-36-22-45-45-15-65z"></path>
+            <path d="M380 140c25-14 71-26 133-20 39 4 74 20 95 51-18 28-44 34-68 34-28 1-55 15-80 33-31 21-66 24-102 8-24-10-45-36-41-55 9-18 31-36 63-51z"></path>
+            <path d="M625 176c29-18 57-25 93-22 44 4 77 19 110 54-19 18-42 25-61 24-31-1-57 8-76 25-29 25-69 24-105 5-25-13-39-31-36-49 6-16 33-28 75-37z"></path>
+            <path d="M734 296c26-12 54-15 83-10 27 5 55 18 85 41-16 14-34 18-48 17-20-1-38 4-55 16-20 14-47 17-74 9-21-6-37-20-39-35 5-14 18-28 48-38z"></path>
+            <path d="M238 296c17-12 45-22 75-22 31 0 54 11 72 30-12 18-28 24-44 24-21 0-41 8-56 20-18 14-43 15-67 8-17-5-32-19-32-33 2-10 19-20 52-27z"></path>
+          </g>
+          <g>
+            <circle class="review-map-node risk" cx="308" cy="184" r="10"></circle>
+            <circle class="review-map-node" cx="247" cy="180" r="7"></circle>
+            <circle class="review-map-node risk" cx="598" cy="196" r="9"></circle>
+            <circle class="review-map-node" cx="702" cy="188" r="8"></circle>
+            <circle class="review-map-node" cx="808" cy="318" r="8"></circle>
+            <circle class="review-map-node risk" cx="214" cy="314" r="8"></circle>
+          </g>
+          <g stroke="rgba(142, 197, 255, 0.32)" stroke-width="1.5" fill="none" opacity="0.9">
+            <path d="M308 184C390 192 496 188 598 196"></path>
+            <path d="M598 196C636 188 676 186 702 188"></path>
+            <path d="M702 188C748 212 780 254 808 318"></path>
+            <path d="M214 314C254 260 270 214 308 184"></path>
+          </g>
+        </svg>
+
+        <div class="review-map-caption">
+          <div>
+            <div class="review-label">Map meaning</div>
+            <strong>Regional infrastructure and exposure observations</strong>
+            <p>Not actor origin, not customer geography, and not live attack telemetry.</p>
+          </div>
+          <div class="review-map-legend">
+            <span><span class="review-dot critical"></span>highest-pressure cluster</span>
+            <span><span class="review-dot info"></span>supporting observation</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="review-rail">
+      <div class="review-detail-panel">
+        <div class="review-detail-head">
+          <div>
+            <div class="review-label">Regional brief</div>
+            <h2 class="review-detail-title">Western Europe</h2>
+          </div>
+          <div class="review-score">
+            <div class="review-mini-label">tracked threats</div>
+            <div class="review-score-value">6</div>
+          </div>
+        </div>
+        <p class="review-detail-copy">
+          The mockup shifts the detail panel toward a concise intelligence brief. The region summary, dominant vectors,
+          and top records align into one compact side rail rather than many similarly weighted boxes.
+        </p>
+        <div class="review-intel-grid">
+          <div class="review-mini-card">
+            <div class="review-mini-label">Anchor precision</div>
+            <strong>Regional only</strong>
+            <p class="review-summary-copy">Large-scale infrastructure concentration inferred from source material.</p>
+          </div>
+          <div class="review-mini-card">
+            <div class="review-mini-label">Dominant vectors</div>
+            <strong>Supply chain, credential theft</strong>
+            <p class="review-summary-copy">Vector labels are concise and kept in analyst vocabulary.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="review-list-card">
+        <div class="review-list-head">
+          <div>
+            <div class="review-label">Top records</div>
+            <h2 class="review-card-title">Regional exposure leaders</h2>
+          </div>
+        </div>
+        <div class="review-list">
+          {
+            regions.map((region) => (
+              <div class="review-feed-item">
+                <div class="review-feed-head">
+                  <div>
+                    <div class="review-feed-title">{region.name}</div>
+                    <div class="review-badge-row" style="margin-top:8px;">
+                      <span class="review-badge neutral">{region.observations} observations</span>
+                    </div>
+                  </div>
+                  <div class="review-score">
+                    <div class="review-mini-label">threats</div>
+                    <div class="review-score-value">{region.threats}</div>
+                  </div>
+                </div>
+                <p class="review-card-copy">{region.dominant}</p>
+              </div>
+            ))
+          }
+        </div>
+      </div>
+
+      <div class="review-note">
+        <div class="review-label">Coverage note</div>
+        <p class="review-summary-copy">
+          Unmapped records still stay explicit, but the language becomes tighter: "kept off-map pending defensible geography"
+          is more credible than longer helper copy explaining what the page is not.
+        </p>
+      </div>
+    </div>
+  </section>
+</ReviewLayout>

--- a/src/pages/design-review/threats.astro
+++ b/src/pages/design-review/threats.astro
@@ -1,0 +1,177 @@
+---
+import ReviewLayout from '../../components/design-review/ReviewLayout.astro';
+
+const rows = [
+  {
+    title: 'Inference endpoint takeover via poisoned orchestration package',
+    severity: 'critical',
+    status: 'active',
+    score: '9.4',
+    models: 'OpenAI, Claude, OSS',
+    vector: 'supply chain',
+    summary: 'Maintainer trust was abused to move a credential-harvesting package into an orchestration workflow used near model-serving paths.',
+    source: 'JFrog advisory + maintainer follow-up',
+    published: 'Mar 24',
+  },
+  {
+    title: 'Prompt-chain jailbreak bypassing internal guardrail scaffolding',
+    severity: 'high',
+    status: 'investigating',
+    score: '8.1',
+    models: 'OpenAI, Claude',
+    vector: 'jailbreak',
+    summary: 'The pattern chains instruction redirection and retrieval abuse to escape a wrapper layer rather than the base model alone.',
+    source: 'Vendor disclosure + independent repro',
+    published: 'Mar 22',
+  },
+  {
+    title: 'Training artifact leak through model-serving debug residue',
+    severity: 'high',
+    status: 'active',
+    score: '7.8',
+    models: 'OSS / HuggingFace',
+    vector: 'data exposure',
+    summary: 'Residual debug output exposed training-adjacent artifacts to unauthenticated retrieval in a commonly cloned deployment pattern.',
+    source: 'Community report',
+    published: 'Mar 19',
+  },
+];
+---
+
+<ReviewLayout
+  title="ThreatParallax Design Review - Threats"
+  currentPage="threats"
+  pageTitle="Threats mockup"
+  pageSummary="A more integrated operator surface where filters, result context, and record structure support fast triage instead of feeling like separate layers."
+>
+  <section class="review-band">
+    <div class="review-band-header">
+      <div>
+        <div class="review-label">Operator surface</div>
+        <h2 class="review-section-title">Filters are treated like part of the workbench, not a separate explainer section.</h2>
+      </div>
+      <div class="review-chip-row">
+        <span class="review-chip">27 threats in scope</span>
+        <span class="review-chip">3 active filters</span>
+        <span class="review-chip">sorted by score</span>
+      </div>
+    </div>
+
+    <div class="review-filter-grid">
+      <label class="review-filter-card">
+        <span class="review-filter-label">Search corpus</span>
+        <input type="search" value="supply chain" />
+      </label>
+      <label class="review-filter-card">
+        <span class="review-filter-label">Severity</span>
+        <select><option>Critical + High</option></select>
+      </label>
+      <label class="review-filter-card">
+        <span class="review-filter-label">Model</span>
+        <select><option>All models</option></select>
+      </label>
+      <label class="review-filter-card">
+        <span class="review-filter-label">Vector</span>
+        <select><option>Supply chain</option></select>
+      </label>
+      <label class="review-filter-card">
+        <span class="review-filter-label">Status</span>
+        <select><option>Active + investigating</option></select>
+      </label>
+      <button class="review-filter-action" type="button">Clear</button>
+    </div>
+  </section>
+
+  <section class="review-grid two-col">
+    <div class="review-table">
+      <div class="review-table-head">
+        <div>
+          <div class="review-label">Threat results</div>
+          <h2 class="review-table-title">Professional operator scanning</h2>
+        </div>
+        <div class="review-meta">Compact metadata, stronger title emphasis, and tighter summary control</div>
+      </div>
+
+      {
+        rows.map((row) => (
+          <article class="review-table-row">
+            <div class="review-operator-head">
+              <div>
+                <div class="review-badge-row">
+                  <span class:list={['review-badge', row.severity]}>{row.severity}</span>
+                  <span class="review-badge neutral">{row.status}</span>
+                  <span class="review-badge neutral">{row.vector}</span>
+                </div>
+                <div class="review-feed-title" style="margin-top:12px;">{row.title}</div>
+              </div>
+              <div class="review-score">
+                <div class="review-mini-label">blended score</div>
+                <div class="review-score-value">{row.score}</div>
+              </div>
+            </div>
+            <p class="review-card-copy">{row.summary}</p>
+            <div class="review-scan-grid">
+              <div class="review-mini-card">
+                <div class="review-mini-label">Models</div>
+                <strong>{row.models}</strong>
+              </div>
+              <div class="review-mini-card">
+                <div class="review-mini-label">Source</div>
+                <strong>{row.source}</strong>
+              </div>
+              <div class="review-mini-card">
+                <div class="review-mini-label">Published</div>
+                <strong>{row.published}</strong>
+              </div>
+              <div class="review-mini-card">
+                <div class="review-mini-label">Next action</div>
+                <strong>Open canonical record</strong>
+              </div>
+            </div>
+          </article>
+        ))
+      }
+    </div>
+
+    <div class="review-rail">
+      <div class="review-sidebar-card">
+        <div class="review-card-header">
+          <div>
+            <div class="review-label">Result summary</div>
+            <h2 class="review-card-title">Active queue stays visible</h2>
+          </div>
+        </div>
+        <div class="review-detail-grid">
+          <div class="review-mini-card">
+            <div class="review-mini-label">Matching threats</div>
+            <strong>27</strong>
+            <p class="review-summary-copy">Current query returns a narrow but still meaningful queue.</p>
+          </div>
+          <div class="review-mini-card">
+            <div class="review-mini-label">Newest item</div>
+            <strong>Mar 24</strong>
+            <p class="review-summary-copy">Recent enough to justify the current sort order.</p>
+          </div>
+          <div class="review-mini-card">
+            <div class="review-mini-label">Critical in queue</div>
+            <strong>4</strong>
+            <p class="review-summary-copy">Count treatment is stronger, but still restrained.</p>
+          </div>
+          <div class="review-mini-card">
+            <div class="review-mini-label">Model families</div>
+            <strong>8</strong>
+            <p class="review-summary-copy">Enough spread to keep model tags visually important.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="review-note">
+        <div class="review-label">Why it scans faster</div>
+        <p class="review-summary-copy">
+          The mockup removes redundant helper text and uses a cleaner title-to-metadata rhythm. Each row says:
+          what it is, how bad it is, why it matters, and where to go next.
+        </p>
+      </div>
+    </div>
+  </section>
+</ReviewLayout>

--- a/src/styles/design-review.css
+++ b/src/styles/design-review.css
@@ -1,0 +1,904 @@
+:root {
+  --review-bg: #071018;
+  --review-bg-soft: #0b1520;
+  --review-surface: rgba(10, 18, 29, 0.88);
+  --review-surface-2: rgba(13, 23, 36, 0.92);
+  --review-surface-3: rgba(18, 31, 46, 0.92);
+  --review-text: #f1f6fb;
+  --review-text-soft: #b4c1d0;
+  --review-text-muted: #7f90a5;
+  --review-border: rgba(145, 169, 201, 0.16);
+  --review-border-strong: rgba(145, 169, 201, 0.28);
+  --review-info: #8ec5ff;
+  --review-low: #55d39f;
+  --review-med: #f5cf72;
+  --review-high: #ffb36d;
+  --review-critical: #ff7a7a;
+  --review-shadow-lg: 0 30px 80px rgba(0, 0, 0, 0.34);
+  --review-shadow-md: 0 18px 46px rgba(0, 0, 0, 0.28);
+  --review-radius-xl: 28px;
+  --review-radius-lg: 22px;
+  --review-radius-md: 16px;
+  --review-radius-sm: 12px;
+  --review-display: 'Space Grotesk', sans-serif;
+  --review-sans: 'Manrope', sans-serif;
+  --review-mono: 'IBM Plex Mono', monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgba(82, 123, 178, 0.18), transparent 24%),
+    radial-gradient(circle at 82% 0%, rgba(66, 105, 158, 0.12), transparent 26%),
+    linear-gradient(180deg, #071018 0%, #08111a 42%, #09121b 100%);
+  color: var(--review-text);
+  font-family: var(--review-sans);
+}
+
+body {
+  letter-spacing: -0.01em;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.review-app {
+  min-height: 100vh;
+  padding: 20px;
+}
+
+.review-shell {
+  max-width: 1480px;
+  margin: 0 auto;
+  display: grid;
+  gap: 18px;
+}
+
+.review-header,
+.review-body,
+.review-card,
+.review-hero-card,
+.review-band,
+.review-table,
+.review-map-card,
+.review-detail-panel,
+.review-note,
+.review-summary-card,
+.review-list-card,
+.review-page-header,
+.review-sidebar-card,
+.review-stage-card {
+  border: 1px solid var(--review-border);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.015));
+  box-shadow: var(--review-shadow-md);
+}
+
+.review-header {
+  border-radius: var(--review-radius-xl);
+  padding: 18px 22px;
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: center;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.015)),
+    rgba(8, 15, 24, 0.96);
+}
+
+.review-brand {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+
+.review-brand-mark {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  border: 1px solid var(--review-border-strong);
+  background:
+    linear-gradient(135deg, rgba(142, 197, 255, 0.22), rgba(85, 211, 159, 0.08)),
+    rgba(255, 255, 255, 0.03);
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.review-brand-mark svg {
+  width: 20px;
+  height: 20px;
+}
+
+.review-eyebrow,
+.review-kicker,
+.review-label,
+.review-chip,
+.review-meta,
+.review-pill,
+.review-stat-label,
+.review-filter-label,
+.review-section-label,
+.review-table-label,
+.review-mini-label {
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 800;
+  color: var(--review-text-muted);
+}
+
+.review-brand-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.review-brand-title {
+  font-family: var(--review-display);
+  font-size: 22px;
+  line-height: 1;
+  letter-spacing: -0.04em;
+}
+
+.review-brand-sub {
+  color: var(--review-text-soft);
+  font-size: 13px;
+}
+
+.review-header-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.review-pill {
+  padding: 10px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--review-border);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--review-text-soft);
+  letter-spacing: 0.08em;
+}
+
+.review-pill strong {
+  color: var(--review-text);
+}
+
+.review-body {
+  border-radius: var(--review-radius-xl);
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 248px minmax(0, 1fr);
+  gap: 12px;
+  background: rgba(8, 14, 22, 0.84);
+}
+
+.review-nav {
+  border-radius: 20px;
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--review-border);
+  display: grid;
+  align-content: start;
+  gap: 14px;
+}
+
+.review-nav-links {
+  display: grid;
+  gap: 8px;
+}
+
+.review-nav-link {
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid transparent;
+  display: grid;
+  gap: 6px;
+  color: var(--review-text-soft);
+}
+
+.review-nav-link strong {
+  color: var(--review-text);
+  font-size: 14px;
+}
+
+.review-nav-link:hover {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: var(--review-border);
+}
+
+.review-nav-link.active {
+  background: linear-gradient(180deg, rgba(142, 197, 255, 0.14), rgba(142, 197, 255, 0.05));
+  border-color: rgba(142, 197, 255, 0.26);
+}
+
+.review-nav-note {
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid var(--review-border);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--review-text-soft);
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.review-content {
+  border-radius: 20px;
+  padding: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.01)),
+    rgba(7, 14, 22, 0.94);
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
+.review-page-header {
+  border-radius: var(--review-radius-lg);
+  padding: 20px 22px;
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: end;
+}
+
+.review-page-header h1,
+.review-hero-title,
+.review-section-title,
+.review-card-title,
+.review-detail-title,
+.review-map-title,
+.review-table-title {
+  margin: 0;
+  font-family: var(--review-display);
+  letter-spacing: -0.045em;
+}
+
+.review-page-header h1 {
+  font-size: clamp(28px, 4vw, 44px);
+  line-height: 0.98;
+  max-width: 12ch;
+}
+
+.review-page-header p {
+  margin: 8px 0 0;
+  max-width: 56ch;
+  color: var(--review-text-soft);
+  line-height: 1.65;
+}
+
+.review-page-header .review-meta {
+  color: var(--review-text-soft);
+  letter-spacing: 0.1em;
+}
+
+.review-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.review-grid.two-col {
+  grid-template-columns: minmax(0, 1.32fr) minmax(320px, 0.82fr);
+}
+
+.review-grid.three-col {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.review-grid.kpi-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.review-hero-card {
+  border-radius: var(--review-radius-lg);
+  padding: 22px;
+  display: grid;
+  gap: 18px;
+  background:
+    radial-gradient(circle at top right, rgba(142, 197, 255, 0.14), transparent 28%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.015));
+}
+
+.review-hero-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: start;
+}
+
+.review-hero-copy {
+  display: grid;
+  gap: 10px;
+  max-width: 72ch;
+}
+
+.review-hero-title {
+  font-size: clamp(30px, 4vw, 48px);
+  line-height: 0.96;
+  max-width: 13ch;
+}
+
+.review-hero-copy p,
+.review-card-copy,
+.review-list-copy,
+.review-detail-copy,
+.review-summary-copy {
+  color: var(--review-text-soft);
+  line-height: 1.65;
+  margin: 0;
+}
+
+.review-chip-row,
+.review-inline-list {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.review-chip {
+  padding: 8px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--review-border);
+  background: rgba(255, 255, 255, 0.03);
+  letter-spacing: 0.08em;
+  color: var(--review-text-soft);
+}
+
+.review-hero-rail {
+  min-width: 240px;
+  display: grid;
+  gap: 12px;
+}
+
+.review-summary-card,
+.review-sidebar-card,
+.review-card,
+.review-note,
+.review-stage-card,
+.review-detail-panel,
+.review-list-card,
+.review-table,
+.review-map-card {
+  border-radius: var(--review-radius-lg);
+  padding: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.review-stat-value,
+.review-kpi-value,
+.review-score-value {
+  font-family: var(--review-display);
+  letter-spacing: -0.05em;
+  line-height: 0.9;
+}
+
+.review-kpi {
+  border-radius: 18px;
+  padding: 18px;
+  border: 1px solid var(--review-border);
+  background: rgba(255, 255, 255, 0.02);
+  display: grid;
+  gap: 12px;
+  min-height: 148px;
+}
+
+.review-kpi-value {
+  font-size: clamp(28px, 3vw, 42px);
+}
+
+.review-kpi.critical {
+  background: linear-gradient(180deg, rgba(255, 122, 122, 0.14), rgba(255, 122, 122, 0.05));
+  border-color: rgba(255, 122, 122, 0.22);
+}
+
+.review-kpi.info {
+  background: linear-gradient(180deg, rgba(142, 197, 255, 0.14), rgba(142, 197, 255, 0.05));
+  border-color: rgba(142, 197, 255, 0.22);
+}
+
+.review-kpi.low {
+  background: linear-gradient(180deg, rgba(85, 211, 159, 0.14), rgba(85, 211, 159, 0.05));
+  border-color: rgba(85, 211, 159, 0.22);
+}
+
+.review-band {
+  border-radius: var(--review-radius-lg);
+  padding: 18px;
+  display: grid;
+  gap: 14px;
+}
+
+.review-band-header,
+.review-card-header,
+.review-list-head,
+.review-table-head,
+.review-detail-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.review-section-title,
+.review-card-title,
+.review-map-title,
+.review-detail-title,
+.review-table-title {
+  font-size: 22px;
+  line-height: 1;
+}
+
+.review-chart {
+  height: 220px;
+  border-radius: 18px;
+  border: 1px solid rgba(142, 197, 255, 0.14);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01)),
+    repeating-linear-gradient(
+      to top,
+      rgba(145, 169, 201, 0.08) 0,
+      rgba(145, 169, 201, 0.08) 1px,
+      transparent 1px,
+      transparent 42px
+    );
+  padding: 16px 16px 12px;
+  display: grid;
+  align-content: end;
+}
+
+.review-chart-bars {
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 10px;
+  align-items: end;
+}
+
+.review-chart-bar {
+  border-radius: 12px 12px 4px 4px;
+  background: linear-gradient(180deg, rgba(142, 197, 255, 0.82), rgba(142, 197, 255, 0.18));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.review-chart-bar.critical {
+  background: linear-gradient(180deg, rgba(255, 122, 122, 0.9), rgba(255, 122, 122, 0.2));
+}
+
+.review-split {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+}
+
+.review-list {
+  display: grid;
+  gap: 12px;
+}
+
+.review-list-item,
+.review-feed-item,
+.review-table-row,
+.review-operator-row,
+.review-method-item,
+.review-source-item {
+  border: 1px solid var(--review-border);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.review-feed-item,
+.review-operator-row {
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.review-feed-head,
+.review-operator-head,
+.review-record-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: start;
+}
+
+.review-feed-title,
+.review-record-title {
+  font-size: 20px;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.review-badge-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.review-badge {
+  padding: 6px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--review-border);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.review-badge.critical {
+  color: var(--review-critical);
+  background: rgba(255, 122, 122, 0.12);
+  border-color: rgba(255, 122, 122, 0.22);
+}
+
+.review-badge.high {
+  color: var(--review-high);
+  background: rgba(255, 179, 109, 0.12);
+  border-color: rgba(255, 179, 109, 0.22);
+}
+
+.review-badge.medium {
+  color: var(--review-med);
+  background: rgba(245, 207, 114, 0.12);
+  border-color: rgba(245, 207, 114, 0.2);
+}
+
+.review-badge.low {
+  color: var(--review-low);
+  background: rgba(85, 211, 159, 0.12);
+  border-color: rgba(85, 211, 159, 0.2);
+}
+
+.review-badge.neutral {
+  color: var(--review-text-soft);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.review-score {
+  min-width: 102px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--review-border);
+  background: rgba(255, 255, 255, 0.03);
+  text-align: right;
+}
+
+.review-score-value {
+  font-size: 34px;
+}
+
+.review-scan-grid,
+.review-detail-grid,
+.review-evidence-grid,
+.review-filter-grid,
+.review-intel-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.review-scan-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.review-filter-grid {
+  grid-template-columns: 1.4fr repeat(4, minmax(0, 1fr)) auto;
+  align-items: end;
+}
+
+.review-intel-grid,
+.review-detail-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.review-mini-card,
+.review-filter-card {
+  border-radius: 14px;
+  border: 1px solid var(--review-border);
+  background: rgba(255, 255, 255, 0.02);
+  padding: 12px 13px;
+  display: grid;
+  gap: 6px;
+}
+
+.review-filter-card input,
+.review-filter-card select {
+  width: 100%;
+  border: 1px solid var(--review-border);
+  border-radius: 12px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--review-text);
+  font: inherit;
+}
+
+.review-filter-action {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--review-border-strong);
+  background: rgba(142, 197, 255, 0.1);
+  color: var(--review-text);
+  font-weight: 700;
+}
+
+.review-map-layout {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.32fr) minmax(360px, 0.82fr);
+}
+
+.review-map-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.review-map-stage {
+  min-height: 560px;
+  position: relative;
+  padding: 22px;
+  background:
+    radial-gradient(circle at 50% 18%, rgba(142, 197, 255, 0.12), transparent 28%),
+    linear-gradient(180deg, rgba(13, 22, 34, 0.98), rgba(9, 16, 25, 0.98));
+}
+
+.review-map-stage svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.review-map-node {
+  fill: rgba(142, 197, 255, 0.9);
+  stroke: rgba(255, 255, 255, 0.78);
+  stroke-width: 1.2;
+}
+
+.review-map-node.risk {
+  fill: rgba(255, 122, 122, 0.92);
+}
+
+.review-map-caption {
+  position: absolute;
+  left: 22px;
+  right: 22px;
+  bottom: 22px;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(142, 197, 255, 0.14);
+  background: rgba(6, 11, 18, 0.74);
+  backdrop-filter: blur(12px);
+}
+
+.review-map-caption p {
+  margin: 6px 0 0;
+  max-width: 36ch;
+  color: var(--review-text-soft);
+  line-height: 1.55;
+}
+
+.review-map-legend {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  align-items: center;
+  color: var(--review-text-soft);
+  font-size: 12px;
+}
+
+.review-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  display: inline-block;
+  margin-right: 6px;
+}
+
+.review-dot.info {
+  background: var(--review-info);
+}
+
+.review-dot.critical {
+  background: var(--review-critical);
+}
+
+.review-rail {
+  display: grid;
+  gap: 16px;
+  align-self: start;
+}
+
+.review-map-metric {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  border-radius: 16px;
+  border: 1px solid var(--review-border);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.review-map-metric strong {
+  font-size: 26px;
+  font-family: var(--review-display);
+  line-height: 0.96;
+}
+
+.review-operator-headline {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.review-operator-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.review-operator-row {
+  grid-template-columns: minmax(0, 1.4fr) minmax(180px, 0.7fr);
+  align-items: start;
+}
+
+.review-operator-main {
+  display: grid;
+  gap: 12px;
+}
+
+.review-operator-side {
+  display: grid;
+  gap: 10px;
+}
+
+.review-metadata-grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.review-metadata-item {
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid var(--review-border);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.review-table {
+  padding: 0;
+  overflow: hidden;
+}
+
+.review-table-head {
+  padding: 18px;
+  border-bottom: 1px solid var(--review-border);
+}
+
+.review-table-row {
+  margin: 0 18px 12px;
+  padding: 16px;
+  display: grid;
+  gap: 12px;
+}
+
+.review-table-row:first-of-type {
+  margin-top: 18px;
+}
+
+.review-detail-hero {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.24fr) minmax(280px, 0.76fr);
+}
+
+.review-record-title {
+  max-width: 16ch;
+}
+
+.review-record-rail {
+  display: grid;
+  gap: 12px;
+}
+
+.review-detail-panel {
+  gap: 16px;
+}
+
+.review-source-list,
+.review-method-list {
+  display: grid;
+  gap: 10px;
+}
+
+.review-source-item,
+.review-method-item {
+  padding: 14px;
+  display: grid;
+  gap: 8px;
+}
+
+.review-source-item p,
+.review-method-item p,
+.review-metadata-item p {
+  margin: 0;
+  color: var(--review-text-soft);
+  line-height: 1.55;
+}
+
+.review-footer-note {
+  color: var(--review-text-muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+@media (max-width: 1120px) {
+  .review-body,
+  .review-grid.two-col,
+  .review-map-layout,
+  .review-split,
+  .review-detail-hero,
+  .review-operator-row {
+    grid-template-columns: 1fr;
+  }
+
+  .review-nav {
+    order: 2;
+  }
+
+  .review-header,
+  .review-page-header,
+  .review-hero-top,
+  .review-band-header,
+  .review-card-header,
+  .review-list-head,
+  .review-detail-head,
+  .review-map-caption,
+  .review-feed-head,
+  .review-operator-head,
+  .review-record-head {
+    flex-direction: column;
+    align-items: start;
+  }
+
+  .review-header-meta {
+    justify-content: flex-start;
+  }
+
+  .review-hero-rail {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 880px) {
+  .review-grid.kpi-grid,
+  .review-grid.three-col,
+  .review-scan-grid,
+  .review-detail-grid,
+  .review-evidence-grid,
+  .review-intel-grid,
+  .review-metadata-grid,
+  .review-filter-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .review-app {
+    padding: 12px;
+  }
+
+  .review-content {
+    padding: 14px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a self-contained ThreatParallax design-review area with static mockup pages for overview, threat map, threats, and threat detail
- add a design review brief describing weaknesses, target visual direction, page goals, simplifications, emphasis, and implementation rules
- add review notes outlining the major deltas, rationale, and phased implementation priorities

## Validation
- `npm.cmd test`
- `npm run build`